### PR TITLE
feat: import the agent pipeline from prepify (v0.1.0)

### DIFF
--- a/.github/actions/find-pr-for-issue/action.yml
+++ b/.github/actions/find-pr-for-issue/action.yml
@@ -1,0 +1,39 @@
+name: find-pr-for-issue
+description: Find the open PR that closes a given issue, via GitHub's own closingIssuesReferences
+
+inputs:
+  issue_number:
+    required: true
+
+outputs:
+  pr_number:
+    description: Empty if no open PR currently closes this issue
+    value: ${{ steps.find.outputs.pr_number }}
+  head_ref:
+    value: ${{ steps.find.outputs.head_ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Find PR
+      id: find
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        NUM: ${{ inputs.issue_number }}
+      run: |
+        if ! [[ "$NUM" =~ ^[0-9]+$ ]]; then
+          echo "Error: issue_number must be numeric, got: $NUM" >&2
+          exit 1
+        fi
+
+        PR_JSON=$(gh pr list --repo ${{ github.repository }} --state open --json number,headRefName,closingIssuesReferences \
+          --jq '[.[] | select(.closingIssuesReferences[]?.number == '"$NUM"')][0]')
+
+        if [[ -z "$PR_JSON" || "$PR_JSON" == "null" ]]; then
+          echo "pr_number=" >> "$GITHUB_OUTPUT"
+          echo "head_ref=" >> "$GITHUB_OUTPUT"
+        else
+          echo "pr_number=$(echo "$PR_JSON" | jq -r .number)" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(echo "$PR_JSON" | jq -r .headRefName)" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/resolve-agent-config/action.yml
+++ b/.github/actions/resolve-agent-config/action.yml
@@ -1,0 +1,54 @@
+name: resolve-agent-config
+description: >
+  Resolve the effective execution limits for one agent job via
+  agent-config.sh (precedence: config file > Actions var PIPELINE_* > built-in).
+  The PIPELINE_* Actions vars are passed in as inputs — the `vars` context is
+  not available inside composite actions.
+
+inputs:
+  agent:
+    description: refiner | estimator | coder | reviewer
+    required: true
+  pipeline_model:
+    required: false
+    default: ""
+  pipeline_max_turns:
+    required: false
+    default: ""
+  pipeline_timeout_minutes:
+    required: false
+    default: ""
+  pipeline_max_output_tokens:
+    required: false
+    default: ""
+  pipeline_cost_warn_usd:
+    required: false
+    default: ""
+
+outputs:
+  model:
+    value: ${{ steps.resolve.outputs.model }}
+  max_turns:
+    value: ${{ steps.resolve.outputs.max_turns }}
+  timeout_minutes:
+    value: ${{ steps.resolve.outputs.timeout_minutes }}
+  max_output_tokens:
+    value: ${{ steps.resolve.outputs.max_output_tokens }}
+  cost_warn_usd:
+    value: ${{ steps.resolve.outputs.cost_warn_usd }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve agent config
+      id: resolve
+      shell: bash
+      env:
+        PIPELINE_MODEL: ${{ inputs.pipeline_model }}
+        PIPELINE_MAX_TURNS: ${{ inputs.pipeline_max_turns }}
+        PIPELINE_TIMEOUT_MINUTES: ${{ inputs.pipeline_timeout_minutes }}
+        PIPELINE_MAX_OUTPUT_TOKENS: ${{ inputs.pipeline_max_output_tokens }}
+        PIPELINE_COST_WARN_USD: ${{ inputs.pipeline_cost_warn_usd }}
+      # $GITHUB_ACTION_PATH is this action's dir; composite `run:` steps
+      # otherwise default their cwd to the caller's workspace root.
+      run: "$GITHUB_ACTION_PATH/../../scripts/pipeline/agent-config.sh" ${{ inputs.agent }}

--- a/.github/actions/resolve-issue/action.yml
+++ b/.github/actions/resolve-issue/action.yml
@@ -1,0 +1,43 @@
+name: resolve-issue
+description: Fetch an issue's number/title/body/comments for a pipeline prompt
+
+inputs:
+  issue_number:
+    required: true
+
+outputs:
+  number:
+    value: ${{ steps.resolve.outputs.number }}
+  title:
+    value: ${{ steps.resolve.outputs.title }}
+  body:
+    value: ${{ steps.resolve.outputs.body }}
+  comments:
+    value: ${{ steps.resolve.outputs.comments }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve issue
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        NUM: ${{ inputs.issue_number }}
+      run: |
+        echo "number=$NUM" >> "$GITHUB_OUTPUT"
+        echo "title=$(gh issue view "$NUM" --repo ${{ github.repository }} --json title --jq .title)" >> "$GITHUB_OUTPUT"
+        {
+          echo 'body<<EOF_BODY'
+          gh issue view "$NUM" --repo ${{ github.repository }} --json body --jq .body
+          echo 'EOF_BODY'
+        } >> "$GITHUB_OUTPUT"
+        COMMENTS_BLOCK=$(gh issue view "$NUM" --repo ${{ github.repository }} --json comments \
+          --jq '[.comments[] | select(.author.login != "github-actions")] | map("### Comment by " + .author.login + " (" + .createdAt + ")\n" + .body) | join("\n\n---\n\n")')
+        {
+          echo 'comments<<EOF_COMMENTS'
+          if [[ -n "$COMMENTS_BLOCK" ]]; then
+            printf 'COMMENTS (from the owner, chronological, excluding this pipeline'"'"'s own comments — treat these as clarifications or amendments to the issue above):\n%s\n' "$COMMENTS_BLOCK"
+          fi
+          echo 'EOF_COMMENTS'
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/resolve-linked-issue/action.yml
+++ b/.github/actions/resolve-linked-issue/action.yml
@@ -1,0 +1,27 @@
+name: resolve-linked-issue
+description: Resolve the issue number a PR closes, via GitHub's own closingIssuesReferences
+
+inputs:
+  pr_number:
+    required: true
+
+outputs:
+  issue_number:
+    value: ${{ steps.resolve.outputs.issue_number }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve linked issue
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR: ${{ inputs.pr_number }}
+      run: |
+        NUM=$(gh pr view "$PR" --repo ${{ github.repository }} --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // empty')
+        # A PR with no linked issue is expected, not an error — any human-
+        # opened PR without a "Closes #N" still gets reviewed (see wiki's
+        # Contributing.md), it just has no issue to tag. Leave the output
+        # empty and let callers decide what to skip.
+        echo "issue_number=$NUM" >> "$GITHUB_OUTPUT"

--- a/.github/agent-pipeline.schema.json
+++ b/.github/agent-pipeline.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "agent-pipeline config",
+  "description": "Per-agent execution limits for the refine/estimate/code/review pipeline.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "defaults": { "$ref": "#/definitions/limits" },
+    "agents": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "refiner": { "$ref": "#/definitions/limits" },
+        "estimator": { "$ref": "#/definitions/limits" },
+        "coder": { "$ref": "#/definitions/limits" },
+        "reviewer": { "$ref": "#/definitions/limits" }
+      }
+    }
+  },
+  "definitions": {
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "model": { "type": "string", "minLength": 1 },
+        "max_turns": { "type": "integer", "minimum": 1 },
+        "timeout_minutes": { "type": "integer", "minimum": 1 },
+        "max_output_tokens": {
+          "type": "integer",
+          "minimum": 16000,
+          "description": "Safety ceiling, not a cost lever. Lowering it truncates edits and review bodies mid-write."
+        },
+        "cost_warn_usd": { "type": "number", "exclusiveMinimum": 0 }
+      }
+    }
+  }
+}

--- a/.github/prompts/code-fix.md
+++ b/.github/prompts/code-fix.md
@@ -1,0 +1,52 @@
+You are addressing reviewer feedback on an already-open PR for a Prepify
+issue — not implementing from scratch.
+
+Input: the original issue, and — scoped to the latest review round only —
+the reviewer's most recent `REQUEST_CHANGES` review (its summary body and
+its line-anchored inline comments) plus any PR conversation posted after
+it. Earlier rounds are already addressed in prior commits; don't reopen
+them. You're on the PR's existing branch.
+
+## Scope your changes to the feedback
+
+Address exactly what the reviewer flagged. Don't re-open discussion on
+parts of the diff the reviewer didn't comment on, and don't use this as
+an opportunity to refactor or expand scope beyond what's needed to
+resolve their comments — that's how review rounds spiral instead of
+converging.
+
+If a review comment is itself wrong or based on a misunderstanding, you
+may push back — but do so as a normal reply on the PR, not by silently
+ignoring the feedback or by re-litigating it in the next review round
+without ever having said so. To comment on the PR: write your reasoning
+to `./.pr-comment.md` and run
+`./.github/scripts/gh-safe/comment-pr.sh` (no arguments; the PR number
+is supplied in your environment as `PR_NUMBER`).
+
+Never modify `.github/workflows/` or `.github/scripts/` — they define this
+pipeline's own sandbox and `push-branch.sh` rejects any push that touches
+them. If addressing the feedback requires such a change, stop and explain
+that on the PR (`comment-pr.sh`) instead.
+
+Read `CLAUDE.md` and `wiki/Contributing.md` if you need a refresher on
+conventions. Re-run the project's build and test commands before pushing
+and keep them green — the same bar applies to a fix commit as to the
+original implementation, and a red `test` or `build` check sends the
+issue to a human rather than back to you for another round.
+
+## Commit and push
+
+Commit your changes normally and push to the **existing branch** — do
+not create a new branch or a new PR. Pushing to the branch updates the
+already-open PR directly and is what re-triggers the reviewer.
+`push-branch.sh` squashes the branch to one commit and force-pushes it,
+so your earlier PR commits are replaced, not appended to.
+
+```
+git add -A
+git commit -m "..."
+./.github/scripts/gh-safe/push-branch.sh
+```
+
+Do nothing else — no label edits, no PR creation, no other comments. The
+workflow handles status transitions after your run completes.

--- a/.github/prompts/code-fix.md
+++ b/.github/prompts/code-fix.md
@@ -1,5 +1,5 @@
-You are addressing reviewer feedback on an already-open PR for a Prepify
-issue — not implementing from scratch.
+You are addressing reviewer feedback on an already-open PR — not
+implementing from scratch.
 
 Input: the original issue, and — scoped to the latest review round only —
 the reviewer's most recent `REQUEST_CHANGES` review (its summary body and
@@ -10,42 +10,42 @@ them. You're on the PR's existing branch.
 ## Scope your changes to the feedback
 
 Address exactly what the reviewer flagged. Don't re-open discussion on
-parts of the diff the reviewer didn't comment on, and don't use this as
-an opportunity to refactor or expand scope beyond what's needed to
-resolve their comments — that's how review rounds spiral instead of
-converging.
+parts of the diff the reviewer didn't comment on, and don't use this as an
+opportunity to refactor or expand scope beyond what's needed to resolve
+their comments — that's how review rounds spiral instead of converging.
 
-If a review comment is itself wrong or based on a misunderstanding, you
-may push back — but do so as a normal reply on the PR, not by silently
-ignoring the feedback or by re-litigating it in the next review round
-without ever having said so. To comment on the PR: write your reasoning
-to `./.pr-comment.md` and run
-`./.github/scripts/gh-safe/comment-pr.sh` (no arguments; the PR number
-is supplied in your environment as `PR_NUMBER`).
+If a review comment is itself wrong or based on a misunderstanding, you may
+push back — but do so as a normal reply on the PR, not by silently ignoring
+the feedback or re-litigating it in the next round without ever having said
+so. To comment on the PR: write your reasoning to `./.pr-comment.md` and
+run `.interns/.github/scripts/gh-safe/comment-pr.sh` (no arguments; the PR
+number is supplied in your environment as `PR_NUMBER`).
 
-Never modify `.github/workflows/` or `.github/scripts/` — they define this
-pipeline's own sandbox and `push-branch.sh` rejects any push that touches
-them. If addressing the feedback requires such a change, stop and explain
-that on the PR (`comment-pr.sh`) instead.
+Don't modify CI or pipeline configuration — anything under
+`.github/workflows/`, or pipeline scripts the repo marks as protected.
+`push-branch.sh` rejects any push that touches those paths. If addressing
+the feedback requires such a change, stop and explain that on the PR
+(`comment-pr.sh`) instead.
 
-Read `CLAUDE.md` and `wiki/Contributing.md` if you need a refresher on
-conventions. Re-run the project's build and test commands before pushing
-and keep them green — the same bar applies to a fix commit as to the
-original implementation, and a red `test` or `build` check sends the
-issue to a human rather than back to you for another round.
+Re-check the repo's own conventions (`CLAUDE.md` / `AGENTS.md`, any
+contributor guide, or the existing code) if you need a refresher. Re-run
+the project's build and test commands before pushing and keep them green —
+the same bar applies to a fix commit as to the original implementation, and
+a red check sends the issue to a human rather than back to you for another
+round.
 
 ## Commit and push
 
-Commit your changes normally and push to the **existing branch** — do
-not create a new branch or a new PR. Pushing to the branch updates the
+Commit your changes normally and push to the **existing branch** — do not
+create a new branch or a new PR. Pushing to the branch updates the
 already-open PR directly and is what re-triggers the reviewer.
-`push-branch.sh` squashes the branch to one commit and force-pushes it,
-so your earlier PR commits are replaced, not appended to.
+`push-branch.sh` squashes the branch to one commit and force-pushes it, so
+your earlier PR commits are replaced, not appended to.
 
 ```
 git add -A
 git commit -m "..."
-./.github/scripts/gh-safe/push-branch.sh
+.interns/.github/scripts/gh-safe/push-branch.sh
 ```
 
 Do nothing else — no label edits, no PR creation, no other comments. The

--- a/.github/prompts/code.md
+++ b/.github/prompts/code.md
@@ -1,64 +1,71 @@
-You are implementing a GitHub issue for Prepify — opening a PR, not just
-writing code locally.
+You are implementing a GitHub issue — opening a PR, not just writing code
+locally.
 
-Input: the issue title, body (Value / Scope / Acceptance Criteria), and
-any owner comments.
+Input: the issue title, body (Value / Scope / Acceptance Criteria), and any
+owner comments.
 
 ## Ground yourself first
 
-Read `CLAUDE.md` for the project's tech stack and conventions, and
-`wiki/Contributing.md` for branch-naming and PR conventions before
-writing anything. Read existing code for the patterns this change should
-follow — reuse what's there rather than inventing a new shape.
+Read and follow the repo's own agent instructions — `CLAUDE.md`,
+`AGENTS.md`, or whatever equivalent it ships — for tech stack, conventions,
+and any rules on migrations, tests, or commits. If the repo has a
+contributor guide (a `CONTRIBUTING` file, a wiki page), read it for
+branch-naming and PR conventions. If none of that exists, infer the
+conventions from the existing code and match them.
+
+Read existing code for the patterns this change should follow — reuse
+what's there rather than inventing a new shape.
 
 ## Implement
 
-Work through every item in Acceptance Criteria. Don't add scope beyond
-what Value/Scope/Acceptance Criteria actually ask for, and don't leave
-anything half-finished — if something in Acceptance Criteria can't be
-completed (missing information, a blocked dependency), stop rather than
-opening a partial PR: write an explanation to
-`./.issue-pipeline-comment.md` and run
-`./.github/scripts/gh-safe/comment-issue.sh` (no arguments).
+Work through every item in Acceptance Criteria. Don't add scope beyond what
+Value/Scope/Acceptance Criteria actually ask for, and don't leave anything
+half-finished — if something in Acceptance Criteria can't be completed
+(missing information, a blocked dependency), stop rather than opening a
+partial PR: write an explanation to `./.issue-pipeline-comment.md` and run
+`.interns/.github/scripts/gh-safe/comment-issue.sh` (no arguments).
 
-Follow this repo's code style: self-documenting names over comments,
-no speculative abstraction, no unrequested refactors of surrounding code.
+Match the surrounding code: naming, structure, error handling, test style,
+comment density. Don't introduce patterns the repo doesn't already use, add
+speculative abstraction, or refactor code the issue didn't ask you to
+touch.
 
-Never modify `.github/workflows/` or `.github/scripts/` — they define this
-pipeline's own sandbox and `push-branch.sh` rejects any push that touches
-them. If the issue seems to require such a change, stop and comment on the
-issue instead of opening a PR.
+Don't modify CI or pipeline configuration — anything under
+`.github/workflows/`, or pipeline scripts the repo marks as protected.
+`push-branch.sh` rejects any push that touches those paths. If the issue
+seems to require such a change, stop and comment on the issue instead of
+opening a PR.
 
 Tests are your responsibility. Add or update tests for the behaviour you
 change, then run the project's build and test commands and make sure they
-pass. The reviewer does not run tests — the `test` and `build` CI checks
-are the gate, and a red check sends the issue straight to a human instead
-of back to you. Do not open the PR with a failing build or failing tests:
-if you can't get them green, stop and comment on the issue instead.
+pass. The reviewer does not run tests — the CI checks are the gate, and a
+red check sends the issue straight to a human instead of back to you. Do
+not open the PR with a failing build or failing tests: if you can't get
+them green, stop and comment on the issue instead.
 
 ## Branch and commit
 
 Branch name: `<type>/<short-slug>`, matching the type your PR title will
-carry (see `wiki/Contributing.md`) — e.g. `feat/quiz-export` for a PR
-titled `feat: ...`. Commit your changes with a normal, clear commit
-message. `push-branch.sh` collapses the branch to a single commit before
-pushing, so don't rely on your intermediate commit structure surviving.
+carry — e.g. `feat/quiz-export` for a PR titled `feat: ...`. Commit your
+changes with a normal, clear commit message. `push-branch.sh` collapses the
+branch to a single commit before pushing, so don't rely on your
+intermediate commit structure surviving.
 
 ## Open the PR
 
 PR title: a [Conventional Commit](https://www.conventionalcommits.org/)
-subject line (`feat:`, `fix:`, `refactor:`, etc.) — this becomes the
-squash-merge commit on `main`, which release-please reads to pick the
-next version and write the changelog, so get the type right.
+subject line (`feat:`, `fix:`, `refactor:`, etc.). If the repo
+squash-merges and derives releases from commit history, this line becomes
+that commit — get the type right.
 
-PR body: a concise, meaningful summary of what changed and why —
-readable on its own without needing to open the issue.
+PR body: a concise, meaningful summary of what changed and why — readable
+on its own without needing to open the issue.
 
 1. Write the PR title (single line) to `./.pr-title.txt`.
 2. Write the PR body to `./.pr-body.md`. Do not add a "Closes #N" line
    yourself — the script that opens the PR adds it automatically.
-3. Push your branch: `./.github/scripts/gh-safe/push-branch.sh` (no arguments).
-4. Run `./.github/scripts/gh-safe/open-pr.sh` (no arguments).
+3. Push your branch: `.interns/.github/scripts/gh-safe/push-branch.sh` (no arguments).
+4. Run `.interns/.github/scripts/gh-safe/open-pr.sh` (no arguments).
 
-Do nothing else — no label edits, no other comments. The workflow
-handles status transitions after your run completes.
+Do nothing else — no label edits, no other comments. The workflow handles
+status transitions after your run completes.

--- a/.github/prompts/code.md
+++ b/.github/prompts/code.md
@@ -1,0 +1,64 @@
+You are implementing a GitHub issue for Prepify — opening a PR, not just
+writing code locally.
+
+Input: the issue title, body (Value / Scope / Acceptance Criteria), and
+any owner comments.
+
+## Ground yourself first
+
+Read `CLAUDE.md` for the project's tech stack and conventions, and
+`wiki/Contributing.md` for branch-naming and PR conventions before
+writing anything. Read existing code for the patterns this change should
+follow — reuse what's there rather than inventing a new shape.
+
+## Implement
+
+Work through every item in Acceptance Criteria. Don't add scope beyond
+what Value/Scope/Acceptance Criteria actually ask for, and don't leave
+anything half-finished — if something in Acceptance Criteria can't be
+completed (missing information, a blocked dependency), stop rather than
+opening a partial PR: write an explanation to
+`./.issue-pipeline-comment.md` and run
+`./.github/scripts/gh-safe/comment-issue.sh` (no arguments).
+
+Follow this repo's code style: self-documenting names over comments,
+no speculative abstraction, no unrequested refactors of surrounding code.
+
+Never modify `.github/workflows/` or `.github/scripts/` — they define this
+pipeline's own sandbox and `push-branch.sh` rejects any push that touches
+them. If the issue seems to require such a change, stop and comment on the
+issue instead of opening a PR.
+
+Tests are your responsibility. Add or update tests for the behaviour you
+change, then run the project's build and test commands and make sure they
+pass. The reviewer does not run tests — the `test` and `build` CI checks
+are the gate, and a red check sends the issue straight to a human instead
+of back to you. Do not open the PR with a failing build or failing tests:
+if you can't get them green, stop and comment on the issue instead.
+
+## Branch and commit
+
+Branch name: `<type>/<short-slug>`, matching the type your PR title will
+carry (see `wiki/Contributing.md`) — e.g. `feat/quiz-export` for a PR
+titled `feat: ...`. Commit your changes with a normal, clear commit
+message. `push-branch.sh` collapses the branch to a single commit before
+pushing, so don't rely on your intermediate commit structure surviving.
+
+## Open the PR
+
+PR title: a [Conventional Commit](https://www.conventionalcommits.org/)
+subject line (`feat:`, `fix:`, `refactor:`, etc.) — this becomes the
+squash-merge commit on `main`, which release-please reads to pick the
+next version and write the changelog, so get the type right.
+
+PR body: a concise, meaningful summary of what changed and why —
+readable on its own without needing to open the issue.
+
+1. Write the PR title (single line) to `./.pr-title.txt`.
+2. Write the PR body to `./.pr-body.md`. Do not add a "Closes #N" line
+   yourself — the script that opens the PR adds it automatically.
+3. Push your branch: `./.github/scripts/gh-safe/push-branch.sh` (no arguments).
+4. Run `./.github/scripts/gh-safe/open-pr.sh` (no arguments).
+
+Do nothing else — no label edits, no other comments. The workflow
+handles status transitions after your run completes.

--- a/.github/prompts/estimate.md
+++ b/.github/prompts/estimate.md
@@ -1,0 +1,76 @@
+You are estimating effort for a refined Prepify issue.
+
+Input: the issue title and its refined body (Value / Scope / Acceptance
+Criteria sections).
+
+If the issue has a `type:epic` label, do not estimate it. Epics are
+intent and scope, not a sized deliverable — sizing them in dev-effort
+terms doesn't mean anything before they're broken into sub-issues.
+Instead, comment on the issue explaining that epics aren't estimated
+directly (size the sub-issues once they're filed), and swap labels:
+`--remove-label "status:refined" --add-label "status:ready"`. Then stop.
+
+Prepify is a small app with one person driving dozens of tickets, most
+of them implemented by an AI coding agent — coding itself is cheap here.
+The real cost is whatever the owner personally has to touch: risk,
+review, and anything an agent can't verify itself. Size against that
+reality, not generic story points or dev-days.
+
+If Scope or Acceptance Criteria are too ambiguous to size at all (not
+just uncertain — genuinely unsizeable without knowing which of two very
+different implementations is intended), stop. Do not force out a size.
+Instead, comment on the issue tagging the owner (their handle is given
+in your instructions) with one specific, answerable question, and report
+that you stopped for clarification instead of estimating.
+
+You have read access to the repository (checked out at the working
+directory) and the wiki (checked out at `wiki/`). Read code and wiki
+pages when it would sharpen the estimate — e.g. checking whether Scope
+reuses an existing pattern (smaller) or requires a new one (bigger), or
+whether the wiki's Architecture page implies more moving parts than the
+issue text alone suggests. Don't guess about the codebase when you can
+check it.
+
+Read Scope and Acceptance Criteria, then score each of these four
+criteria Low / Mid / High, weighted equally, with one sentence of
+reasoning grounded in the specific Scope or Acceptance Criteria content
+— not a restatement of the issue:
+
+- **Blast Radius** — risk of breaking something that already works.
+  Auth, migrations, payment-adjacent flows, and anything touching
+  shared/prod state score High; an isolated new module or pure addition
+  scores Low.
+- **Touch** — roughly how many files/modules need to change, and how
+  much context an agent (and a reviewer) has to hold at once. A
+  single-file change is Low; a change spanning several modules or a
+  migration plus app code is High.
+- **Human Involvement** — work the owner has to do by hand because an
+  agent can't: manual testing against a real UI/API, GCP/Supabase
+  console changes, secret rotation, anything in the "verify actually
+  working" category that can't be automated. None needed is Low;
+  hands-on config or manual verification across multiple surfaces is
+  High.
+- **Review Overhead** — how many passes this will take: number of PRs,
+  whether it needs an architecture discussion before code, how many
+  iteration loops between owner and agent before it's mergeable. One
+  PR, one clean review pass is Low; multiple PRs or back-and-forth
+  design review is High.
+
+Then roll the four scores into a single SIZE (XS/S/M/L/XL) — a holistic
+call, not a formula. Mostly-Low scores across the board is XS/S; a mix
+of Mid is M; multiple Highs is L; a High on more than one criterion at
+once, or an unsizeable mix, is XL.
+
+Output exactly this format:
+
+BLAST RADIUS: <Low|Mid|High> — <one sentence>
+TOUCH: <Low|Mid|High> — <one sentence>
+HUMAN INVOLVEMENT: <Low|Mid|High> — <one sentence>
+REVIEW OVERHEAD: <Low|Mid|High> — <one sentence>
+SIZE: <XS|S|M|L|XL>
+<one sentence on which criterion or criteria drove the size>
+
+If SIZE is XL, add a line:
+SPLIT: <one sentence on where the natural seams are to break this up>
+
+Output nothing else — no preamble, no closing remarks.

--- a/.github/prompts/estimate.md
+++ b/.github/prompts/estimate.md
@@ -1,65 +1,55 @@
-You are estimating effort for a refined Prepify issue.
+You are estimating effort for a refined issue.
 
-Input: the issue title and its refined body (Value / Scope / Acceptance
-Criteria sections).
+Input: the issue title, its refined body (Value / Scope / Acceptance
+Criteria), and any comments on it.
 
-If the issue has a `type:epic` label, do not estimate it. Epics are
-intent and scope, not a sized deliverable — sizing them in dev-effort
-terms doesn't mean anything before they're broken into sub-issues.
-Instead, comment on the issue explaining that epics aren't estimated
-directly (size the sub-issues once they're filed), and swap labels:
+If the issue has a `type:epic` label, do not estimate it. Epics are intent
+and scope, not a sized deliverable — sizing them in dev-effort terms
+doesn't mean anything before they're broken into sub-issues. Instead,
+comment on the issue explaining that epics aren't estimated directly (size
+the sub-issues once they're filed), and swap labels:
 `--remove-label "status:refined" --add-label "status:ready"`. Then stop.
 
-Prepify is a small app with one person driving dozens of tickets, most
-of them implemented by an AI coding agent — coding itself is cheap here.
-The real cost is whatever the owner personally has to touch: risk,
-review, and anything an agent can't verify itself. Size against that
+Assume coding itself is cheap — most tickets are implemented by an AI
+coding agent. The real cost is whatever the owner personally has to touch:
+risk, review, and anything an agent can't verify itself. Size against that
 reality, not generic story points or dev-days.
 
-If Scope or Acceptance Criteria are too ambiguous to size at all (not
-just uncertain — genuinely unsizeable without knowing which of two very
-different implementations is intended), stop. Do not force out a size.
-Instead, comment on the issue tagging the owner (their handle is given
-in your instructions) with one specific, answerable question, and report
-that you stopped for clarification instead of estimating.
-
 You have read access to the repository (checked out at the working
-directory) and the wiki (checked out at `wiki/`). Read code and wiki
-pages when it would sharpen the estimate — e.g. checking whether Scope
-reuses an existing pattern (smaller) or requires a new one (bigger), or
-whether the wiki's Architecture page implies more moving parts than the
-issue text alone suggests. Don't guess about the codebase when you can
-check it.
+directory) and any contributor guide or wiki it ships. Read code and docs
+when it would sharpen the estimate — whether Scope reuses an existing
+pattern (smaller) or needs a new one (bigger), whether the architecture
+implies more moving parts than the issue text suggests. Don't guess about
+the codebase when you can check it.
 
-Read Scope and Acceptance Criteria, then score each of these four
-criteria Low / Mid / High, weighted equally, with one sentence of
-reasoning grounded in the specific Scope or Acceptance Criteria content
-— not a restatement of the issue:
+Read Scope and Acceptance Criteria, then score each of these four criteria
+Low / Mid / High, weighted equally, with one sentence of reasoning grounded
+in the specific Scope or Acceptance Criteria content — not a restatement of
+the issue:
 
-- **Blast Radius** — risk of breaking something that already works.
-  Auth, migrations, payment-adjacent flows, and anything touching
+- **Blast Radius** — risk of breaking something that already works. Auth,
+  data migrations, payment-adjacent flows, and anything touching
   shared/prod state score High; an isolated new module or pure addition
   scores Low.
-- **Touch** — roughly how many files/modules need to change, and how
-  much context an agent (and a reviewer) has to hold at once. A
-  single-file change is Low; a change spanning several modules or a
-  migration plus app code is High.
-- **Human Involvement** — work the owner has to do by hand because an
-  agent can't: manual testing against a real UI/API, GCP/Supabase
-  console changes, secret rotation, anything in the "verify actually
-  working" category that can't be automated. None needed is Low;
-  hands-on config or manual verification across multiple surfaces is
-  High.
+- **Touch** — roughly how many files/modules need to change, and how much
+  context an agent (and a reviewer) has to hold at once. A single-file
+  change is Low; a change spanning several modules, or a migration plus app
+  code, is High.
+- **Human Involvement** — work the owner has to do by hand because an agent
+  can't: manual testing against a real UI/API, cloud-console or dashboard
+  changes, secret rotation, anything in the "verify actually working"
+  category that can't be automated. None needed is Low; hands-on config or
+  manual verification across multiple surfaces is High.
 - **Review Overhead** — how many passes this will take: number of PRs,
   whether it needs an architecture discussion before code, how many
-  iteration loops between owner and agent before it's mergeable. One
-  PR, one clean review pass is Low; multiple PRs or back-and-forth
-  design review is High.
+  iteration loops between owner and agent before it's mergeable. One PR,
+  one clean review pass is Low; multiple PRs or back-and-forth design
+  review is High.
 
 Then roll the four scores into a single SIZE (XS/S/M/L/XL) — a holistic
-call, not a formula. Mostly-Low scores across the board is XS/S; a mix
-of Mid is M; multiple Highs is L; a High on more than one criterion at
-once, or an unsizeable mix, is XL.
+call, not a formula. Mostly-Low across the board is XS/S; a mix of Mid is
+M; multiple Highs is L; a High on more than one criterion at once, or an
+unsizeable mix, is XL.
 
 Output exactly this format:
 
@@ -74,3 +64,16 @@ If SIZE is XL, add a line:
 SPLIT: <one sentence on where the natural seams are to break this up>
 
 Output nothing else — no preamble, no closing remarks.
+
+## When to stop instead of estimating
+
+Stop, comment on the issue tagging the owner (their handle is in your
+instructions) with one specific question, and report that you stopped for
+clarification, in either of these cases:
+
+1. **Unsizeable ambiguity** — Scope or Acceptance Criteria are genuinely
+   unsizeable without knowing which of two very different implementations
+   is intended. Don't force out a size.
+2. **Missing prerequisites** — the ticket depends on something not built or
+   not decided yet, so estimating it now is guesswork. Say what's missing
+   and that it should be estimated once that lands.

--- a/.github/prompts/refine.md
+++ b/.github/prompts/refine.md
@@ -1,54 +1,51 @@
-You are refining a GitHub issue draft for Prepify before it enters the backlog.
+You are refining a GitHub issue draft before it enters the backlog.
 
-Input: the raw issue title and body.
+Input: the raw issue title and body, plus any comments already on it.
 
 ## Step 1: pick the type
 
-Four issue types exist, each with a template at
-`.github/ISSUE_TEMPLATE/`: `spike.md` (research/decision, no code
-deliverable), `bug.md` (something is broken), `coding-task.md` (pure
-implementation work), `epic.md` (a raw idea or theme that will break
-down into several tickets — no Acceptance Criteria, since the work
-itself isn't scoped yet). Determine which one applies:
+Four issue types exist. Determine which one applies:
+
+- `spike` — research or a decision, no code deliverable
+- `bug` — something is broken
+- `coding-task` — pure implementation work
+- `epic` — a raw idea or theme that will break down into several tickets;
+  no Acceptance Criteria, since the work itself isn't scoped yet
+
+Rules:
 
 - If the issue already has a `type:spike`, `type:bug`, `type:coding-task`,
   or `type:epic` label, use that — do not second-guess it.
-- Otherwise, infer the type from the title and body content.
+- Otherwise, infer the type from the title and body.
 - If it's genuinely ambiguous between two types (not just unclear in
-  detail, but shaped differently enough that the template choice changes
-  what the ticket even asks for), that counts as the kind of blocking
-  ambiguity covered in the clarification rule below — ask the owner which
-  type applies instead of guessing.
+  detail, but shaped differently enough that the type choice changes what
+  the ticket even asks for), that's the kind of blocking ambiguity covered
+  in the clarification rule below — ask the owner instead of guessing.
 
-Read the matching template file and use its exact section structure —
-same headings, same order.
+If the repo has an `.github/ISSUE_TEMPLATE/` file matching the chosen type,
+read it and use its exact section structure — same headings, same order.
+Otherwise use this structure:
+
+- **spike** — Context, Question, Options considered, Recommendation
+- **bug** — What happens, Expected, Steps to reproduce, Notes
+- **coding-task** — Value, Scope, Acceptance Criteria
+- **epic** — Value, Themes / sub-areas (no Acceptance Criteria)
 
 ## Step 2: fill it in
 
-Rewrite the body into the chosen template's sections, carrying over every
-concrete requirement already in the original text — you are clarifying
-and structuring, not inventing new scope. Leave HTML comments
-(`<!-- ... -->`) out of the final output; they're authoring guidance for
-the template, not content to preserve.
-
-If you cannot fill a section without guessing at a fact only the owner
-would know (not just a missing detail you can flag inline with "Needs
-owner input:", but something that blocks writing that section at all —
-e.g. two plausible interpretations that lead to genuinely different
-work), stop. Do not guess, and do not force out a refinement. Instead,
-comment on the issue tagging the owner (their handle is given in your
-instructions) with one specific, answerable question, and report that you
-stopped for clarification instead of editing the body.
+Rewrite the body into the chosen structure, carrying over every concrete
+requirement already in the original text — you are clarifying and
+structuring, not inventing new scope. Leave HTML comments (`<!-- ... -->`)
+out of the final output; they're authoring guidance, not content.
 
 You have read access to the repository (checked out at the working
-directory) and the wiki (checked out at `wiki/`). You may read code and
-wiki pages to ground the refinement in what actually exists — e.g.
-whether something is already built, what an existing pattern looks like,
-or what the wiki's Vision/Architecture pages say direction should be.
-Use this to write a more accurate Scope, not to expand it beyond what the
-issue asked for.
+directory), and to any contributor guide or wiki it ships. Read code and
+docs to ground the refinement in what actually exists — whether something
+is already built, what an existing pattern looks like, what stated
+direction says. Use this to write a more accurate Scope, not to expand it.
 
 Rules:
+
 - If the issue references other issues (#NN) or a parent epic, keep those
   references intact, in their original position if reasonable.
 - If a section can't be filled from the original text, write the section
@@ -58,3 +55,19 @@ Rules:
   Prefer the smaller, more literal reading when the text is unclear.
 - Output only the rewritten issue body in markdown. No preamble, no
   meta-commentary, no code fences wrapping the whole thing.
+
+## When to stop instead of refining
+
+Two cases justify stopping and commenting on the issue (tagging the owner,
+whose handle is in your instructions) with one specific, answerable
+question, then reporting that you stopped for clarification instead of
+editing the body:
+
+1. **Blocking ambiguity** — you cannot fill a section without guessing at a
+   fact only the owner would know: not a missing detail you can flag inline
+   with "Needs owner input:", but two plausible interpretations that lead
+   to genuinely different work.
+2. **Missing prerequisites** — the work depends on something that doesn't
+   exist yet (an unbuilt system, an undecided design, a blocked
+   dependency), so scoping it now would be guesswork. Say what's missing
+   and that refinement should wait until it lands.

--- a/.github/prompts/refine.md
+++ b/.github/prompts/refine.md
@@ -1,0 +1,60 @@
+You are refining a GitHub issue draft for Prepify before it enters the backlog.
+
+Input: the raw issue title and body.
+
+## Step 1: pick the type
+
+Four issue types exist, each with a template at
+`.github/ISSUE_TEMPLATE/`: `spike.md` (research/decision, no code
+deliverable), `bug.md` (something is broken), `coding-task.md` (pure
+implementation work), `epic.md` (a raw idea or theme that will break
+down into several tickets — no Acceptance Criteria, since the work
+itself isn't scoped yet). Determine which one applies:
+
+- If the issue already has a `type:spike`, `type:bug`, `type:coding-task`,
+  or `type:epic` label, use that — do not second-guess it.
+- Otherwise, infer the type from the title and body content.
+- If it's genuinely ambiguous between two types (not just unclear in
+  detail, but shaped differently enough that the template choice changes
+  what the ticket even asks for), that counts as the kind of blocking
+  ambiguity covered in the clarification rule below — ask the owner which
+  type applies instead of guessing.
+
+Read the matching template file and use its exact section structure —
+same headings, same order.
+
+## Step 2: fill it in
+
+Rewrite the body into the chosen template's sections, carrying over every
+concrete requirement already in the original text — you are clarifying
+and structuring, not inventing new scope. Leave HTML comments
+(`<!-- ... -->`) out of the final output; they're authoring guidance for
+the template, not content to preserve.
+
+If you cannot fill a section without guessing at a fact only the owner
+would know (not just a missing detail you can flag inline with "Needs
+owner input:", but something that blocks writing that section at all —
+e.g. two plausible interpretations that lead to genuinely different
+work), stop. Do not guess, and do not force out a refinement. Instead,
+comment on the issue tagging the owner (their handle is given in your
+instructions) with one specific, answerable question, and report that you
+stopped for clarification instead of editing the body.
+
+You have read access to the repository (checked out at the working
+directory) and the wiki (checked out at `wiki/`). You may read code and
+wiki pages to ground the refinement in what actually exists — e.g.
+whether something is already built, what an existing pattern looks like,
+or what the wiki's Vision/Architecture pages say direction should be.
+Use this to write a more accurate Scope, not to expand it beyond what the
+issue asked for.
+
+Rules:
+- If the issue references other issues (#NN) or a parent epic, keep those
+  references intact, in their original position if reasonable.
+- If a section can't be filled from the original text, write the section
+  heading followed by a single line: "Needs owner input:" plus a specific
+  question. Do not guess at business intent.
+- Do not resolve ambiguity by picking the more ambitious interpretation.
+  Prefer the smaller, more literal reading when the text is unclear.
+- Output only the rewritten issue body in markdown. No preamble, no
+  meta-commentary, no code fences wrapping the whole thing.

--- a/.github/prompts/refine.md
+++ b/.github/prompts/refine.md
@@ -22,14 +22,17 @@ Rules:
   the ticket even asks for), that's the kind of blocking ambiguity covered
   in the clarification rule below — ask the owner instead of guessing.
 
-If the repo has an `.github/ISSUE_TEMPLATE/` file matching the chosen type,
-read it and use its exact section structure — same headings, same order.
-Otherwise use this structure:
+Then read the template for that type and use its exact section structure —
+same headings, same order. Look in this order and use the first that
+exists:
 
-- **spike** — Context, Question, Options considered, Recommendation
-- **bug** — What happens, Expected, Steps to reproduce, Notes
-- **coding-task** — Value, Scope, Acceptance Criteria
-- **epic** — Value, Themes / sub-areas (no Acceptance Criteria)
+1. the consuming repo's `.github/ISSUE_TEMPLATE/<type>.md` (so a
+   refiner-written issue matches what humans see in the New Issue picker)
+2. `.interns/templates/issue/<type>.md` — the built-in default, always
+   present
+
+Ignore the YAML frontmatter and HTML comments; they're authoring guidance,
+not body content.
 
 ## Step 2: fill it in
 

--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -1,0 +1,106 @@
+You are reviewing a PR opened against Prepify by the coder agent (or,
+occasionally, a human).
+
+Input: the PR's diff, the number of the linked issue it implements, and
+this repo's conventions. You're only given the linked issue's *number* —
+run `gh issue view <number>` yourself to read its Value/Scope/Acceptance
+Criteria before judging anything against them. If that issue references
+other tickets that matter for context — a parent epic, a sub-issue, a
+ticket it says it depends on or supersedes — run `gh issue view` on
+those too rather than reviewing off the one issue in isolation.
+
+## What to check
+
+- **Correctness** — does the code actually do what the linked issue's
+  Acceptance Criteria ask for? Read the issue, not just the diff.
+- **Security** — injection, unsafe handling of user input, secrets in
+  code, anything from the OWASP top 10 that applies here.
+- **Conventions** — does it follow `CLAUDE.md` (tech stack, code style,
+  migration rules) and match the patterns already used elsewhere in the
+  codebase, rather than inventing a new shape?
+- **Scope** — does it stay within what the issue actually asked for, or
+  does it drag in unrelated refactors, speculative abstraction, or
+  unrequested changes?
+- **Tests** — is the change verified, not just asserted? Does it add or
+  update tests for the behaviour it changes, and are they meaningful
+  (not just present)? You do **not** run `npm test` / `npm run build`
+  yourself — the `test` and `build` CI checks already passed before this
+  review started (that's a hard gate; a red check never reaches you), so
+  treat "is it green" as settled and judge whether the tests that exist
+  actually cover the change.
+
+Read the actual code — don't rubber-stamp based on the PR description
+alone.
+
+## Changes you can't build/test locally
+
+Some changes are verified by CI in ways you can't reproduce in this
+sandbox — e.g. a Terraform diff: there's no `terraform` CLI here, so you
+can't run `plan` yourself. Passing CI is not the same as a correct
+diff — "plan succeeded" only means the HCL is valid, not that the
+resource-level changes are what the issue actually asked for. For these:
+
+1. Run `gh pr checks` to see this PR's checks and find the relevant one
+   (e.g. `plan-shared`, `plan-dev`, `plan-prod`).
+2. Run `gh run view --job=<job-id> --log` (the job ID is in the check's
+   URL) to read that job's actual output — for Terraform, the real
+   add/change/destroy diff, not just pass/fail.
+3. Judge the diff itself against the Acceptance Criteria, the same way
+   you'd judge a code diff — a passing plan with the wrong resource
+   changes is still wrong.
+
+## Verdict
+
+Decide `APPROVE` or `REQUEST_CHANGES`. There's no middle ground — if you
+have a merely-stylistic nitpick that isn't worth blocking on, say so in
+the review body but still approve. Request changes only for things that
+actually need to change before merge: bugs, security issues, missed
+Acceptance Criteria, or a real convention violation.
+
+On a `REQUEST_CHANGES` verdict, every concrete change you want made gets
+its own inline comment anchored to the exact `path`/`line` it concerns,
+saying specifically what's wrong and (where it's not obvious) what would
+fix it — not vague "consider improving this." The summary `body` stays
+short: a sentence or two on the overall state and why you're blocking,
+not a re-listing of the individual changes. A requested change with no
+inline anchor is one the coder has to hunt for — don't make it do that.
+
+`APPROVE` needs no inline comments; add one only for a genuine
+nice-to-have you're explicitly not blocking on.
+
+## If you can't verify something
+
+If something genuinely blocks you from forming a real verdict — a check
+you can't interpret even after reading its log, a tool you need but
+don't have, context that's missing from the issue or PR — don't force
+an APPROVE to get unstuck, and don't guess at REQUEST_CHANGES either.
+Write what specifically blocked you to `./.pr-comment.md` and run
+`./.github/scripts/gh-safe/comment-pr.sh` (no arguments), then stop
+without submitting a review. The workflow's own fallback will flag the
+issue `status:needs-attention` for a human to look at — your comment
+is what tells them why, instead of just "stopped partway through."
+
+## Submitting
+
+Write your review to `./.pr-review.json`:
+
+```json
+{
+  "event": "APPROVE" | "REQUEST_CHANGES",
+  "body": "overall summary of the review",
+  "comments": [
+    {"path": "src/foo.ts", "line": 42, "body": "specific, actionable comment"}
+  ]
+}
+```
+
+`comments` is empty only for a clean `APPROVE`; a `REQUEST_CHANGES`
+verdict carries one entry per change you're asking for. Then
+run `./.github/scripts/gh-safe/submit-pr-review.sh` (no arguments) — this
+is the only way to submit the review; do not call `gh pr review` or the
+GitHub API directly.
+
+Do nothing else: never merge the PR, never edit labels, never comment
+outside of the review itself — except the "can't verify" case above,
+the one deliberate exception. The workflow handles status transitions
+after your run completes based on what you actually submitted.

--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -1,84 +1,80 @@
-You are reviewing a PR opened against Prepify by the coder agent (or,
-occasionally, a human).
+You are reviewing a PR opened by the coder agent (or, occasionally, a
+human).
 
 Input: the PR's diff, the number of the linked issue it implements, and
 this repo's conventions. You're only given the linked issue's *number* —
 run `gh issue view <number>` yourself to read its Value/Scope/Acceptance
 Criteria before judging anything against them. If that issue references
 other tickets that matter for context — a parent epic, a sub-issue, a
-ticket it says it depends on or supersedes — run `gh issue view` on
-those too rather than reviewing off the one issue in isolation.
+ticket it says it depends on or supersedes — run `gh issue view` on those
+too rather than reviewing off the one issue in isolation.
 
 ## What to check
 
 - **Correctness** — does the code actually do what the linked issue's
   Acceptance Criteria ask for? Read the issue, not just the diff.
-- **Security** — injection, unsafe handling of user input, secrets in
-  code, anything from the OWASP top 10 that applies here.
-- **Conventions** — does it follow `CLAUDE.md` (tech stack, code style,
-  migration rules) and match the patterns already used elsewhere in the
-  codebase, rather than inventing a new shape?
+- **Security** — injection, unsafe handling of user input, secrets in code,
+  anything from the OWASP top 10 that applies here.
+- **Conventions** — does it follow the repo's own agent instructions
+  (`CLAUDE.md` / `AGENTS.md`) and match the patterns already used elsewhere
+  in the codebase, rather than inventing a new shape?
 - **Scope** — does it stay within what the issue actually asked for, or
   does it drag in unrelated refactors, speculative abstraction, or
   unrequested changes?
 - **Tests** — is the change verified, not just asserted? Does it add or
-  update tests for the behaviour it changes, and are they meaningful
-  (not just present)? You do **not** run `npm test` / `npm run build`
-  yourself — the `test` and `build` CI checks already passed before this
-  review started (that's a hard gate; a red check never reaches you), so
-  treat "is it green" as settled and judge whether the tests that exist
-  actually cover the change.
+  update tests for the behaviour it changes, and are they meaningful (not
+  just present)? You do **not** run the build or tests yourself — the CI
+  checks already passed before this review started (that's a hard gate; a
+  red check never reaches you), so treat "is it green" as settled and judge
+  whether the tests that exist actually cover the change.
 
 Read the actual code — don't rubber-stamp based on the PR description
 alone.
 
-## Changes you can't build/test locally
+## Checks you can't reproduce in the sandbox
 
-Some changes are verified by CI in ways you can't reproduce in this
-sandbox — e.g. a Terraform diff: there's no `terraform` CLI here, so you
-can't run `plan` yourself. Passing CI is not the same as a correct
-diff — "plan succeeded" only means the HCL is valid, not that the
-resource-level changes are what the issue actually asked for. For these:
+Some CI checks verify things you can't reproduce here — an infrastructure
+plan, a visual-snapshot diff, an integration suite against real services.
+Passing is not the same as correct: "plan succeeded" only means the config
+is valid, not that the changes are what the issue asked for. For these:
 
-1. Run `gh pr checks` to see this PR's checks and find the relevant one
-   (e.g. `plan-shared`, `plan-dev`, `plan-prod`).
+1. Run `gh pr checks` to see this PR's checks and find the relevant one.
 2. Run `gh run view --job=<job-id> --log` (the job ID is in the check's
-   URL) to read that job's actual output — for Terraform, the real
-   add/change/destroy diff, not just pass/fail.
-3. Judge the diff itself against the Acceptance Criteria, the same way
-   you'd judge a code diff — a passing plan with the wrong resource
-   changes is still wrong.
+   URL) to read that job's actual output — the real diff or result, not
+   just pass/fail.
+3. Judge that output against the Acceptance Criteria, the same way you'd
+   judge a code diff. A passing check with the wrong effect is still wrong.
 
 ## Verdict
 
 Decide `APPROVE` or `REQUEST_CHANGES`. There's no middle ground — if you
-have a merely-stylistic nitpick that isn't worth blocking on, say so in
-the review body but still approve. Request changes only for things that
+have a merely-stylistic nitpick that isn't worth blocking on, say so in the
+review body but still approve. Request changes only for things that
 actually need to change before merge: bugs, security issues, missed
 Acceptance Criteria, or a real convention violation.
 
-On a `REQUEST_CHANGES` verdict, every concrete change you want made gets
-its own inline comment anchored to the exact `path`/`line` it concerns,
-saying specifically what's wrong and (where it's not obvious) what would
-fix it — not vague "consider improving this." The summary `body` stays
-short: a sentence or two on the overall state and why you're blocking,
-not a re-listing of the individual changes. A requested change with no
-inline anchor is one the coder has to hunt for — don't make it do that.
+On a `REQUEST_CHANGES` verdict, every concrete change you want made gets its
+own inline comment anchored to the exact `path`/`line` it concerns, saying
+specifically what's wrong and (where it's not obvious) what would fix it —
+not vague "consider improving this." The summary `body` stays short: a
+sentence or two on the overall state and why you're blocking, not a
+re-listing of the individual changes. A requested change with no inline
+anchor is one the coder has to hunt for — don't make it do that.
 
-`APPROVE` needs no inline comments; add one only for a genuine
-nice-to-have you're explicitly not blocking on.
+`APPROVE` needs no inline comments; add one only for a genuine nice-to-have
+you're explicitly not blocking on.
 
 ## If you can't verify something
 
-If something genuinely blocks you from forming a real verdict — a check
-you can't interpret even after reading its log, a tool you need but
-don't have, context that's missing from the issue or PR — don't force
-an APPROVE to get unstuck, and don't guess at REQUEST_CHANGES either.
-Write what specifically blocked you to `./.pr-comment.md` and run
-`./.github/scripts/gh-safe/comment-pr.sh` (no arguments), then stop
-without submitting a review. The workflow's own fallback will flag the
-issue `status:needs-attention` for a human to look at — your comment
-is what tells them why, instead of just "stopped partway through."
+If something genuinely blocks you from forming a real verdict — a check you
+can't interpret even after reading its log, a tool you need but don't have,
+context that's missing from the issue or PR — don't force an APPROVE to get
+unstuck, and don't guess at REQUEST_CHANGES either. Write what specifically
+blocked you to `./.pr-comment.md` and run
+`.interns/.github/scripts/gh-safe/comment-pr.sh` (no arguments), then stop
+without submitting a review. The workflow's own fallback flags the issue
+for a human — your comment is what tells them why, instead of just "stopped
+partway through."
 
 ## Submitting
 
@@ -94,13 +90,13 @@ Write your review to `./.pr-review.json`:
 }
 ```
 
-`comments` is empty only for a clean `APPROVE`; a `REQUEST_CHANGES`
-verdict carries one entry per change you're asking for. Then
-run `./.github/scripts/gh-safe/submit-pr-review.sh` (no arguments) — this
-is the only way to submit the review; do not call `gh pr review` or the
-GitHub API directly.
+`comments` is empty only for a clean `APPROVE`; a `REQUEST_CHANGES` verdict
+carries one entry per change you're asking for. Then run
+`.interns/.github/scripts/gh-safe/submit-pr-review.sh` (no arguments) —
+this is the only way to submit the review; do not call `gh pr review` or
+the GitHub API directly.
 
 Do nothing else: never merge the PR, never edit labels, never comment
-outside of the review itself — except the "can't verify" case above,
-the one deliberate exception. The workflow handles status transitions
-after your run completes based on what you actually submitted.
+outside of the review itself — except the "can't verify" case above, the
+one deliberate exception. The workflow handles status transitions after
+your run completes based on what you actually submitted.

--- a/.github/scripts/gh-safe/comment-issue.sh
+++ b/.github/scripts/gh-safe/comment-issue.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Posts a comment on the issue bound to the triggering event, reading the
+# comment body from a fixed file (written beforehand with the Write tool).
+# Content never passes through a Bash argument — see edit-issue-body.sh
+# for why.
+#
+# Usage: write the comment text to $COMMENT_FILE, then run with no arguments.
+
+set -euo pipefail
+
+COMMENT_FILE="${COMMENT_FILE:-./.issue-pipeline-comment.md}"
+
+ISSUE=$(jq -r '.issue.number // .inputs.issue_number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "Error: no issue number in event payload" >&2
+  exit 1
+fi
+
+if [[ ! -f "$COMMENT_FILE" ]]; then
+  echo "Error: $COMMENT_FILE not found — write the comment there first" >&2
+  exit 1
+fi
+
+gh issue comment "$ISSUE" --body-file "$COMMENT_FILE"

--- a/.github/scripts/gh-safe/comment-pr.sh
+++ b/.github/scripts/gh-safe/comment-pr.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Posts a comment on a PR, reading the comment body from a fixed file
+# (written beforehand with the Write tool) so model-authored text never
+# passes through a Bash argument. Unlike comment-issue.sh, the PR number
+# isn't derivable from the triggering event here (the coder's fix-round
+# run is triggered by an issue label event, not a PR event), so it's
+# supplied explicitly by the workflow.
+#
+# Usage: write the comment text to $COMMENT_FILE, set $PR_NUMBER, then
+# run with no arguments.
+
+set -euo pipefail
+
+COMMENT_FILE="${COMMENT_FILE:-./.pr-comment.md}"
+
+if ! [[ "${PR_NUMBER:-}" =~ ^[0-9]+$ ]]; then
+  echo "Error: PR_NUMBER not set" >&2
+  exit 1
+fi
+
+if [[ ! -f "$COMMENT_FILE" ]]; then
+  echo "Error: $COMMENT_FILE not found — write the comment there first" >&2
+  exit 1
+fi
+
+gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"

--- a/.github/scripts/gh-safe/comment-pr.sh
+++ b/.github/scripts/gh-safe/comment-pr.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 #
-# Posts a comment on a PR, reading the comment body from a fixed file
-# (written beforehand with the Write tool) so model-authored text never
-# passes through a Bash argument. Unlike comment-issue.sh, the PR number
-# isn't derivable from the triggering event here (the coder's fix-round
-# run is triggered by an issue label event, not a PR event), so it's
-# supplied explicitly by the workflow.
+# Comments on a PR, reading the body from a fixed file so model-authored
+# text never passes through a Bash argument. $PR_NUMBER is explicit: the
+# fix-round run is triggered by an issue label event, not a PR event.
 #
-# Usage: write the comment text to $COMMENT_FILE, set $PR_NUMBER, then
-# run with no arguments.
+# Usage: write the text to $COMMENT_FILE, set $PR_NUMBER, run with no args.
 
 set -euo pipefail
 

--- a/.github/scripts/gh-safe/edit-issue-body.sh
+++ b/.github/scripts/gh-safe/edit-issue-body.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Sets the body of the issue bound to the triggering event, reading the
+# new body from a fixed file (written beforehand with the Write tool).
+# Content never passes through a Bash argument, since multi-line markdown
+# containing "#" headers trips Claude Code's static shell-safety checks
+# when quoted as a CLI arg.
+#
+# Usage: write the new body to $BODY_FILE, then run with no arguments.
+
+set -euo pipefail
+
+BODY_FILE="${BODY_FILE:-./.issue-pipeline-body.md}"
+
+ISSUE=$(jq -r '.issue.number // .inputs.issue_number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "Error: no issue number in event payload" >&2
+  exit 1
+fi
+
+if [[ ! -f "$BODY_FILE" ]]; then
+  echo "Error: $BODY_FILE not found — write the new body there first" >&2
+  exit 1
+fi
+
+gh issue edit "$ISSUE" --body-file "$BODY_FILE"

--- a/.github/scripts/gh-safe/edit-issue-labels.sh
+++ b/.github/scripts/gh-safe/edit-issue-labels.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Edits labels on the issue bound to the triggering event.
+# Usage: ./edit-issue-labels.sh --add-label bug --remove-label needs-triage
+#
+# Adapted from anthropics/claude-code-action's scripts/edit-issue-labels.sh.
+
+set -euo pipefail
+
+ISSUE=$(jq -r '.issue.number // .inputs.issue_number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "Error: no issue number in event payload" >&2
+  exit 1
+fi
+
+ADD_LABELS=()
+REMOVE_LABELS=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --add-label)
+      ADD_LABELS+=("$2")
+      shift 2
+      ;;
+    --remove-label)
+      REMOVE_LABELS+=("$2")
+      shift 2
+      ;;
+    *)
+      echo "Error: unknown argument (only --add-label and --remove-label are accepted)" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then
+  exit 1
+fi
+
+VALID_LABELS=$(gh label list --limit 500 --json name --jq '.[].name')
+
+FILTERED_ADD=()
+for label in "${ADD_LABELS[@]}"; do
+  if echo "$VALID_LABELS" | grep -qxF "$label"; then
+    FILTERED_ADD+=("$label")
+  fi
+done
+
+FILTERED_REMOVE=()
+for label in "${REMOVE_LABELS[@]}"; do
+  if echo "$VALID_LABELS" | grep -qxF "$label"; then
+    FILTERED_REMOVE+=("$label")
+  fi
+done
+
+if [[ ${#FILTERED_ADD[@]} -eq 0 && ${#FILTERED_REMOVE[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+GH_ARGS=("issue" "edit" "$ISSUE")
+for label in "${FILTERED_ADD[@]}"; do
+  GH_ARGS+=("--add-label" "$label")
+done
+for label in "${FILTERED_REMOVE[@]}"; do
+  GH_ARGS+=("--remove-label" "$label")
+done
+
+gh "${GH_ARGS[@]}"
+
+if [[ ${#FILTERED_ADD[@]} -gt 0 ]]; then
+  echo "Added: ${FILTERED_ADD[*]}"
+fi
+if [[ ${#FILTERED_REMOVE[@]} -gt 0 ]]; then
+  echo "Removed: ${FILTERED_REMOVE[*]}"
+fi

--- a/.github/scripts/gh-safe/open-pr.sh
+++ b/.github/scripts/gh-safe/open-pr.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Opens a PR from the current branch against the repo's default branch,
+# reading title/body from fixed files (written beforehand with the Write
+# tool) so model-authored text never passes through a Bash argument.
+#
+# Deterministically appends "Closes #<issue>" to the body — this is what
+# lets later workflow steps resolve the linked issue from the PR via
+# GitHub's own closingIssuesReferences, without trusting the model to
+# reproduce that exact line every time.
+#
+# Usage: write the PR title to $TITLE_FILE and body to $BODY_FILE, push
+# the current branch, then run with no arguments.
+
+set -euo pipefail
+
+TITLE_FILE="${TITLE_FILE:-./.pr-title.txt}"
+BODY_FILE="${BODY_FILE:-./.pr-body.md}"
+
+ISSUE=$(jq -r '.issue.number // .inputs.issue_number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "Error: no issue number in event payload" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TITLE_FILE" ]]; then
+  echo "Error: $TITLE_FILE not found — write the PR title there first" >&2
+  exit 1
+fi
+if [[ ! -f "$BODY_FILE" ]]; then
+  echo "Error: $BODY_FILE not found — write the PR body there first" >&2
+  exit 1
+fi
+
+FULL_BODY_FILE=$(mktemp)
+cat "$BODY_FILE" > "$FULL_BODY_FILE"
+printf '\n\nCloses #%s\n' "$ISSUE" >> "$FULL_BODY_FILE"
+
+gh pr create \
+  --title "$(cat "$TITLE_FILE")" \
+  --body-file "$FULL_BODY_FILE"

--- a/.github/scripts/gh-safe/open-pr.sh
+++ b/.github/scripts/gh-safe/open-pr.sh
@@ -1,16 +1,13 @@
 #!/usr/bin/env bash
 #
-# Opens a PR from the current branch against the repo's default branch,
-# reading title/body from fixed files (written beforehand with the Write
-# tool) so model-authored text never passes through a Bash argument.
+# Opens a PR from the current branch, reading title/body from fixed files
+# so model-authored text never passes through a Bash argument.
 #
-# Deterministically appends "Closes #<issue>" to the body — this is what
-# lets later workflow steps resolve the linked issue from the PR via
-# GitHub's own closingIssuesReferences, without trusting the model to
-# reproduce that exact line every time.
+# Appends "Closes #<issue>" deterministically, so later workflow steps can
+# resolve the linked issue via GitHub's closingIssuesReferences rather than
+# trusting the model to reproduce that line.
 #
-# Usage: write the PR title to $TITLE_FILE and body to $BODY_FILE, push
-# the current branch, then run with no arguments.
+# Usage: write $TITLE_FILE and $BODY_FILE, push the branch, run with no args.
 
 set -euo pipefail
 

--- a/.github/scripts/gh-safe/push-branch.sh
+++ b/.github/scripts/gh-safe/push-branch.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Squashes the current branch to one commit and pushes it to origin.
+# Arguments are ignored, so untrusted prompt text can't steer this into
+# --force over main, a different remote, or an explicit refspec.
+#
+# Squash before the guard, not after: squashing collapses an
+# intermediate-only edit to a protected path, and the guard is the
+# backstop for a net change that really touches one.
+
+set -euo pipefail
+
+PROTECTED_PATHS_RE='^\.github/(workflows|scripts/(gh-safe|pipeline))/'
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+case "$BRANCH" in
+  main|master)
+    echo "Error: refusing to push $BRANCH directly" >&2
+    exit 1
+    ;;
+esac
+
+git fetch origin main --quiet
+BASE=$(git merge-base origin/main HEAD)
+
+if [ "$BASE" = "$(git rev-parse HEAD)" ]; then
+  echo "Error: no commits beyond origin/main — nothing to push" >&2
+  exit 1
+fi
+
+MESSAGE=$(git log -1 --format=%B)
+git reset --soft "$BASE"
+git commit --quiet -m "$MESSAGE"
+
+PROTECTED=$(git diff-tree --no-commit-id --name-only -r HEAD | grep -E "$PROTECTED_PATHS_RE" || true)
+
+if [ -n "$PROTECTED" ]; then
+  echo "Error: you are not allowed to change these paths (they define this pipeline's own sandbox):" >&2
+  while IFS= read -r path; do echo "  $path" >&2; done <<< "$PROTECTED"
+  echo "Drop these edits and push again." >&2
+  exit 1
+fi
+
+git push --force-with-lease -u origin "$BRANCH"

--- a/.github/scripts/gh-safe/submit-pr-review.sh
+++ b/.github/scripts/gh-safe/submit-pr-review.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Submits a formal PR review (verdict + optional inline comments) in one
+# atomic call, reading the review from a fixed JSON file (written
+# beforehand with the Write tool) so model-authored text never passes
+# through a Bash argument.
+#
+# Expected JSON shape in $REVIEW_FILE:
+#   {
+#     "event": "APPROVE" | "REQUEST_CHANGES",
+#     "body": "...",
+#     "comments": [{"path": "...", "line": 123, "body": "..."}, ...]
+#   }
+#
+# Usage: write the review JSON to $REVIEW_FILE, then run with no arguments.
+
+set -euo pipefail
+
+REVIEW_FILE="${REVIEW_FILE:-./.pr-review.json}"
+
+PR=$(jq -r '.pull_request.number // .inputs.pr_number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
+if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+  echo "Error: no PR number in event payload" >&2
+  exit 1
+fi
+
+if [[ ! -f "$REVIEW_FILE" ]]; then
+  echo "Error: $REVIEW_FILE not found — write the review JSON there first" >&2
+  exit 1
+fi
+
+EVENT=$(jq -r '.event // empty' "$REVIEW_FILE")
+if [[ "$EVENT" != "APPROVE" && "$EVENT" != "REQUEST_CHANGES" ]]; then
+  echo "Error: review JSON's \"event\" must be APPROVE or REQUEST_CHANGES" >&2
+  exit 1
+fi
+
+gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls/${PR}/reviews" --input "$REVIEW_FILE"

--- a/.github/scripts/pipeline/agent-config.sh
+++ b/.github/scripts/pipeline/agent-config.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Resolves the effective execution limits for one agent job and appends them to
+# $GITHUB_OUTPUT (model, max_turns, timeout_minutes, max_output_tokens,
+# cost_warn_usd). The workflow wires those into --model / --max-turns /
+# CLAUDE_CODE_MAX_OUTPUT_TOKENS / the step timeout, and passes cost_warn_usd to
+# run-summary.sh.
+#
+# Precedence per key: agents.<name>.<key>  >  defaults.<key>  >  Actions var
+# PIPELINE_<KEY>  >  built-in default. The config file is optional — with no
+# file every key falls through to the Actions var or the built-in.
+#
+# A malformed file or an unknown agent/key exits non-zero; the job's
+# `Flag failure` step then posts the standard "pipeline failed" comment.
+#
+# Usage: agent-config.sh <refiner|estimator|coder|reviewer>
+# Env:   AGENT_PIPELINE_CONFIG  config path (default .github/agent-pipeline.yml)
+
+set -euo pipefail
+
+agent="${1:?usage: agent-config.sh <refiner|estimator|coder|reviewer>}"
+config="${AGENT_PIPELINE_CONFIG:-.github/agent-pipeline.yml}"
+
+known_agents=" refiner estimator coder reviewer "
+known_keys=" model max_turns timeout_minutes max_output_tokens cost_warn_usd "
+
+builtin_default() {
+  case "$1" in
+    model)             echo "claude-sonnet-5" ;;
+    max_turns)         echo "40" ;;
+    timeout_minutes)   echo "30" ;;
+    max_output_tokens) echo "32000" ;;
+    cost_warn_usd)     echo "1.50" ;;
+  esac
+}
+
+die() { echo "agent-config: $*" >&2; exit 1; }
+
+[[ "$known_agents" == *" $agent "* ]] || die "unknown agent '$agent'"
+
+if [[ -f "$config" ]]; then
+  yq -e 'type == "!!map"' "$config" >/dev/null 2>&1 || die "$config is not valid YAML or not a mapping"
+
+  while IFS= read -r k; do
+    [[ -z "$k" ]] && continue
+    [[ "$k" == "defaults" || "$k" == "agents" ]] || die "unknown top-level key '$k' in $config"
+  done < <(yq 'keys | .[]' "$config")
+
+  while IFS= read -r k; do
+    [[ -z "$k" ]] && continue
+    [[ "$known_keys" == *" $k "* ]] || die "unknown key 'defaults.$k' in $config"
+  done < <(yq '.defaults // {} | keys | .[]' "$config")
+
+  while IFS= read -r a; do
+    [[ -z "$a" ]] && continue
+    [[ "$known_agents" == *" $a "* ]] || die "unknown agent '$a' in $config"
+    while IFS= read -r k; do
+      [[ -z "$k" ]] && continue
+      [[ "$known_keys" == *" $k "* ]] || die "unknown key 'agents.$a.$k' in $config"
+    done < <(yq ".agents.$a // {} | keys | .[]" "$config")
+  done < <(yq '.agents // {} | keys | .[]' "$config")
+
+  for k in model max_turns timeout_minutes max_output_tokens cost_warn_usd; do
+    v=$(yq ".agents.$agent.$k // .defaults.$k // \"\"" "$config")
+    [[ -n "$v" && "$v" != "null" ]] && printf -v "file_$k" '%s' "$v"
+  done
+fi
+
+resolve() {
+  local key="$1" fvar evar
+  fvar="file_$key"
+  if [[ -n "${!fvar:-}" ]]; then printf '%s' "${!fvar}"; return; fi
+  evar="PIPELINE_$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')"
+  if [[ -n "${!evar:-}" ]]; then printf '%s' "${!evar}"; return; fi
+  builtin_default "$key"
+}
+
+model=$(resolve model)
+max_turns=$(resolve max_turns)
+timeout_minutes=$(resolve timeout_minutes)
+max_output_tokens=$(resolve max_output_tokens)
+cost_warn_usd=$(resolve cost_warn_usd)
+
+is_int_ge() { [[ "$1" =~ ^[0-9]+$ ]] && [[ "$1" -ge "$2" ]]; }
+is_num_gt0() { awk -v x="$1" 'BEGIN { exit !(x + 0 > 0) }'; }
+
+[[ -n "$model" ]] || die "model resolved empty"
+is_int_ge "$max_turns" 1 || die "max_turns must be a positive integer (got '$max_turns')"
+is_int_ge "$timeout_minutes" 1 || die "timeout_minutes must be a positive integer (got '$timeout_minutes')"
+is_int_ge "$max_output_tokens" 16000 \
+  || die "max_output_tokens must be an integer >= 16000 (got '$max_output_tokens') — it is a safety ceiling, not a cost lever"
+is_num_gt0 "$cost_warn_usd" || die "cost_warn_usd must be a positive number (got '$cost_warn_usd')"
+
+{
+  echo "model=$model"
+  echo "max_turns=$max_turns"
+  echo "timeout_minutes=$timeout_minutes"
+  echo "max_output_tokens=$max_output_tokens"
+  echo "cost_warn_usd=$cost_warn_usd"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"
+
+echo "agent-config[$agent]: model=$model max_turns=$max_turns timeout_minutes=$timeout_minutes max_output_tokens=$max_output_tokens cost_warn_usd=$cost_warn_usd" >&2

--- a/.github/scripts/pipeline/apply-verdict.sh
+++ b/.github/scripts/pipeline/apply-verdict.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Acts on the reviewer's latest verdict on a PR.
+#
+# Issue status:* is coarse: status:in-progress for the whole run,
+# status:needs-attention when a human is needed, closed on merge. There is no
+# "approved" issue state — an approved PR is found via its native review state,
+# and the pr:* label only marks which agent is currently working (none, once
+# the reviewer is done). The fix-round decision is read from the verdict, not a
+# label (#133).
+#
+# max_fix_rounds: how many automatic coder fix rounds a PR gets before the loop
+# escalates to a human. Counts CHANGES_REQUESTED reviews (this run's verdict
+# included). Distinct from agent-pipeline.yml's max_turns (turns inside one
+# agent run) — this counts whole agent invocations across a PR, so it stays a
+# workflow-behaviour constant here, not an execution limit in the config file.
+#
+# Usage: apply-verdict.sh <pr> <issue-or-empty>
+#   Env: REVIEWER_BOT (login whose reviews count), GH_TOKEN
+
+set -euo pipefail
+# shellcheck source=.github/scripts/pipeline/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+max_fix_rounds=1
+
+pr="$1"
+issue="${2:-}"
+repo="$GITHUB_REPOSITORY"
+pr_url="${GITHUB_SERVER_URL}/${repo}/pull/${pr}"
+
+last_state=$(gh api "repos/$repo/pulls/$pr/reviews" \
+  --jq '[.[] | select(.user.login==env.REVIEWER_BOT)] | last | .state // empty')
+
+case "$last_state" in
+  APPROVED)
+    set_pr_pipeline_label "$pr"
+    if [[ -n "$issue" ]]; then
+      gh issue comment "$issue" --repo "$repo" --body \
+        "Reviewer approved [PR #$pr]($pr_url) — awaiting owner merge. Run: $(run_url)"
+    fi
+    ;;
+  CHANGES_REQUESTED)
+    rc_count=$(gh api "repos/$repo/pulls/$pr/reviews" \
+      --jq '[.[] | select(.user.login==env.REVIEWER_BOT and .state=="CHANGES_REQUESTED")] | length')
+    if [[ "$rc_count" -gt "$max_fix_rounds" ]]; then
+      set_pr_pipeline_label "$pr"
+      [[ -n "$issue" ]] && set_issue_status "$issue" status:needs-attention
+      gh pr comment "$pr" --repo "$repo" --body \
+        "Second review still requests changes — the automatic fix round didn't converge. Escalating to a human. See the run: $(run_url)"
+    elif [[ -n "$issue" ]]; then
+      set_pr_pipeline_label "$pr" pr:coding
+      # GITHUB_TOKEN label edits don't fire workflow runs (anti-recursion), so
+      # dispatch the coder explicitly as a fix round.
+      gh workflow run code-pipeline.yml --repo "$repo" \
+        --field phase=coder --field issue_number="$issue" --field fix_round=true
+    else
+      set_pr_pipeline_label "$pr"
+      gh pr comment "$pr" --repo "$repo" --body \
+        "Changes requested but this PR has no linked issue — can't dispatch a coder fix round automatically. See the run: $(run_url)"
+    fi
+    ;;
+  *)
+    set_pr_pipeline_label "$pr"
+    [[ -n "$issue" ]] && set_issue_status "$issue" status:needs-attention
+    gh pr comment "$pr" --repo "$repo" --body \
+      "Review run completed without submitting a recognized verdict — likely stopped partway through. See the run: $(run_url)"
+    ;;
+esac

--- a/.github/scripts/pipeline/flag-failure.sh
+++ b/.github/scripts/pipeline/flag-failure.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Common failure handler for the agent phases: send the issue to
+# status:needs-attention, clear any pr:* pipeline label, and post a comment
+# linking the run.
+#
+# Usage: flag-failure.sh --noun <noun> [--issue N] [--pr N] [--fix-round]
+#   --noun       verb for the standard comment ("Automated <noun> failed.")
+#   --issue      issue to move to needs-attention / comment on
+#   --pr         PR to clear labels on / comment on
+#   --fix-round  coder fix-round: comment on the issue with the re-dispatch
+#                command instead of the standard message
+
+set -euo pipefail
+# shellcheck source=.github/scripts/pipeline/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+noun=""
+issue=""
+pr=""
+fix_round=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --noun) noun="$2"; shift 2 ;;
+    --issue) issue="$2"; shift 2 ;;
+    --pr) pr="$2"; shift 2 ;;
+    --fix-round) fix_round=true; shift ;;
+    *) echo "flag-failure: unknown argument $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -n "$pr" ]]; then
+  set_pr_pipeline_label "$pr"
+fi
+if [[ -n "$issue" ]]; then
+  set_issue_status "$issue" status:needs-attention
+fi
+
+if [[ "$fix_round" == true ]]; then
+  gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body \
+    "Automated fix round failed — issue set to \`status:needs-attention\`. Re-dispatch once the cause is addressed: \`gh workflow run code-pipeline.yml -f phase=coder -f issue_number=$issue -f fix_round=true\`. Run: $(run_url)"
+  exit 0
+fi
+
+body="Automated $noun failed. See the run: $(run_url)"
+if [[ -n "$pr" ]]; then
+  gh pr comment "$pr" --repo "$GITHUB_REPOSITORY" --body "$body"
+else
+  gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body "$body"
+fi

--- a/.github/scripts/pipeline/gather-fix-feedback.sh
+++ b/.github/scripts/pipeline/gather-fix-feedback.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Checks out a PR's branch and writes the latest review round to $GITHUB_OUTPUT
+# as `text` for the coder fix-round prompt: the most recent CHANGES_REQUESTED
+# review, its line-anchored comments, and any conversation posted after it.
+# Earlier rounds are already addressed in prior commits — feeding them back in
+# makes the coder re-litigate resolved points (contradicts code-fix.md).
+#
+# Usage: gather-fix-feedback.sh <pr-number> <head-ref> <issue-number>
+
+set -euo pipefail
+
+PR="$1"
+HEAD_REF="$2"
+ISSUE="$3"
+REPO="$GITHUB_REPOSITORY"
+
+if [[ -z "$PR" ]]; then
+  echo "Error: fix round dispatched but no open PR references issue #$ISSUE" >&2
+  exit 1
+fi
+
+git fetch origin "$HEAD_REF"
+git checkout "$HEAD_REF"
+
+LATEST_REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+  --jq '[.[] | select(.state=="CHANGES_REQUESTED")] | last')
+if [[ -z "$LATEST_REVIEW" || "$LATEST_REVIEW" == "null" ]]; then
+  echo "Error: fix round for PR #$PR but no CHANGES_REQUESTED review found" >&2
+  exit 1
+fi
+REVIEW_ID=$(jq -r '.id' <<<"$LATEST_REVIEW")
+REVIEW_TS=$(jq -r '.submitted_at' <<<"$LATEST_REVIEW")
+export REVIEW_ID REVIEW_TS
+
+{
+  echo 'text<<EOF_FEEDBACK'
+  echo "## Latest REQUEST_CHANGES review — $REVIEW_TS"
+  echo
+  jq -r '.body // "(no summary body)"' <<<"$LATEST_REVIEW"
+  echo
+  echo "## Inline comments on that review"
+  gh api "repos/$REPO/pulls/$PR/comments" --paginate \
+    --jq '[.[] | select((.pull_request_review_id | tostring) == env.REVIEW_ID)]
+          | sort_by(.created_at)
+          | .[] | "- \(.path):\(.line // .original_line // "?")\n  \(.body)"'
+  echo
+  echo "## PR conversation posted after that review"
+  gh api "repos/$REPO/issues/$PR/comments" --paginate \
+    --jq '[.[] | select(.created_at > env.REVIEW_TS)]
+          | sort_by(.created_at)
+          | .[] | "### \(.user.login) (\(.created_at))\n\(.body)"'
+  echo 'EOF_FEEDBACK'
+} >> "$GITHUB_OUTPUT"

--- a/.github/scripts/pipeline/handoff-to-review.sh
+++ b/.github/scripts/pipeline/handoff-to-review.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Runs after a successful coder phase. If a PR now references the issue, hand it
+# to the reviewer (the issue stays status:in-progress for the whole active run,
+# #133 — the pr:* label is the only "which agent" signal, and a red check or
+# rejection is read from native PR state, not a label). If no PR was left, the
+# agent stopped for clarification or partway through — flag it for a human.
+#
+# Usage: handoff-to-review.sh <issue> <pr-number-or-empty>
+
+set -euo pipefail
+# shellcheck source=.github/scripts/pipeline/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+issue="$1"
+pr="${2:-}"
+
+if [[ -n "$pr" ]]; then
+  set_pr_pipeline_label "$pr" pr:in-review
+else
+  set_issue_status "$issue" status:needs-attention
+  gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body \
+    "Coder run completed without leaving an open PR referencing this issue — likely stopped for clarification or partway through. See the run: $(run_url)"
+fi

--- a/.github/scripts/pipeline/lib.sh
+++ b/.github/scripts/pipeline/lib.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for the pipeline scripts. Source it, don't execute:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+#
+# Every helper reads the Actions env the workflow already exports:
+# GITHUB_REPOSITORY, GITHUB_SERVER_URL, GITHUB_RUN_ID, GH_TOKEN.
+
+set -euo pipefail
+
+# URL of the current workflow run, for "see the run" links in comments.
+run_url() {
+  echo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+}
+
+# Raw USD cost from a claude-code-action execution file -> 4dp, or "unknown"
+# when the run produced no cost figure.
+format_cost() {
+  local raw="${1:-}"
+  if [[ -n "$raw" ]]; then
+    printf '%.4f' "$raw"
+  else
+    printf 'unknown'
+  fi
+}
+
+# Issue lifecycle labels the coder/reviewer phases move between. The
+# issue-pipeline's own labels (needs-refinement, refined, estimated) are left
+# untouched here.
+_ISSUE_STATUS_LABELS=(status:in-progress status:needs-attention status:ready)
+
+# Move an issue to one lifecycle status, removing whichever of the others it
+# currently carries (a --remove-label for an absent label would fail the whole
+# edit). Best-effort: a failed edit doesn't abort the caller.
+set_issue_status() {
+  local issue="$1" target="$2" current label
+  local args=(issue edit "$issue" --repo "$GITHUB_REPOSITORY" --add-label "$target")
+  current=$(gh issue view "$issue" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")')
+  for label in "${_ISSUE_STATUS_LABELS[@]}"; do
+    [[ "$label" == "$target" ]] && continue
+    [[ ",$current," == *",$label,"* ]] && args+=(--remove-label "$label")
+  done
+  gh "${args[@]}" || true
+  return 0
+}
+
+# The PR label marking which agent is on it now.
+_PR_PIPELINE_LABELS=(pr:coding pr:in-review)
+
+# Set the PR's pipeline label, or clear both when called with no label (the
+# reviewer is done and no agent is active). Only touches labels that change.
+set_pr_pipeline_label() {
+  local pr="$1" target="${2:-}" current label
+  local base=(pr edit "$pr" --repo "$GITHUB_REPOSITORY")
+  local args=("${base[@]}")
+  current=$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")')
+  for label in "${_PR_PIPELINE_LABELS[@]}"; do
+    if [[ "$label" == "$target" ]]; then
+      [[ ",$current," == *",$label,"* ]] || args+=(--add-label "$label")
+    elif [[ ",$current," == *",$label,"* ]]; then
+      args+=(--remove-label "$label")
+    fi
+  done
+  if [[ ${#args[@]} -gt ${#base[@]} ]]; then
+    gh "${args[@]}" || true
+  fi
+  return 0
+}

--- a/.github/scripts/pipeline/report-run.sh
+++ b/.github/scripts/pipeline/report-run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Posts the "<Phase> [pipeline run](url) — cost: $X" comment every agent phase
+# drops on the ticket. Cost tracking lives on the issue (refine, estimate,
+# coder and reviewer all post there) so spend aggregates from one place — see
+# #105. Cost is parsed from the claude-code-action execution file; "unknown"
+# when the run produced none.
+#
+# Usage: report-run.sh <phase> <execution-file> <issue-number> [<pr-number>]
+#   Comments on the issue. Falls back to the PR only when issue-number is
+#   empty — the reviewer on a PR with no linked issue.
+
+set -euo pipefail
+# shellcheck source=.github/scripts/pipeline/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+phase="$1"
+exec_file="$2"
+issue="${3:-}"
+pr="${4:-}"
+
+raw_cost=$(jq -r '[.[] | select(.type=="result")][0].total_cost_usd // empty' "$exec_file" 2>/dev/null || true)
+body="$phase [pipeline run]($(run_url)) — cost: \$$(format_cost "$raw_cost")"
+
+if [[ -n "$issue" ]]; then
+  gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body "$body"
+elif [[ -n "$pr" ]]; then
+  gh pr comment "$pr" --repo "$GITHUB_REPOSITORY" --body "$body"
+else
+  echo "report-run: need an issue or PR number" >&2
+  exit 1
+fi

--- a/.github/scripts/pipeline/route-red-checks.sh
+++ b/.github/scripts/pipeline/route-red-checks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# The `test` / `build` checks aren't green, so the reviewer won't run. The
+# coder writes and runs tests before pushing, so a red check here goes straight
+# to a human rather than back through a coder retry (#133).
+#
+# Usage: route-red-checks.sh <pr> <issue-or-empty> <reason>
+
+set -euo pipefail
+# shellcheck source=.github/scripts/pipeline/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pr="$1"
+issue="${2:-}"
+reason="$3"
+
+set_pr_pipeline_label "$pr"
+gh pr comment "$pr" --repo "$GITHUB_REPOSITORY" --body \
+  "Required checks are not green ($reason) — the reviewer won't run. The coder writes and runs tests before pushing, so this is being sent straight to a human rather than retried. Run: $(run_url)"
+if [[ -n "$issue" ]]; then
+  set_issue_status "$issue" status:needs-attention
+fi

--- a/.github/scripts/pipeline/run-summary.sh
+++ b/.github/scripts/pipeline/run-summary.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# Writes a Markdown run summary to $GITHUB_STEP_SUMMARY so the Actions run page
+# shows what an agent phase did without opening the turn-by-turn step log.
+# Complements report-run.sh: same cost figure, but richer detail and on the run
+# page only, never the ticket.
+#
+# Best-effort — never fails the job. Every gh lookup falls back to a plain line
+# and the caller runs it with `if: always()`, so a summary lands even when the
+# Claude step itself failed.
+#
+# Usage: run-summary.sh <phase> <execution-file> [--issue N] [--pr N]
+#                       [--round initial|fix] [--cost-warn USD]
+#   phase       Coder | Review | Refinement | Estimation
+#   --round     Coder/Review only: whether this run is an initial pass or a fix round
+#   --cost-warn append a ⚠️ line when the run cost exceeds this figure
+#   execution-file may be empty/absent — a SIGKILLed (timed-out) agent step
+#   leaves none; the summary then reports a timeout.
+#   Env: GH_TOKEN; REVIEWER_BOT for the Review phase
+
+set -euo pipefail
+# shellcheck source=.github/scripts/pipeline/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+phase="$1"
+exec_file="${2:-}"
+shift 2
+
+issue=""
+pr=""
+round=""
+cost_warn=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue) issue="$2"; shift 2 ;;
+    --pr) pr="$2"; shift 2 ;;
+    --round) round="$2"; shift 2 ;;
+    --cost-warn) cost_warn="$2"; shift 2 ;;
+    *) echo "run-summary: unknown argument $1" >&2; exit 1 ;;
+  esac
+done
+
+repo="$GITHUB_REPOSITORY"
+summary="${GITHUB_STEP_SUMMARY:?run-summary: GITHUB_STEP_SUMMARY is not set}"
+
+# --- execution-file fields (all optional; a failed run may have none) ----------
+result_field() {
+  [[ -f "$exec_file" ]] || return 0
+  jq -r "[.[] | select(.type==\"result\")][0].$1 // empty" "$exec_file" 2>/dev/null || true
+}
+raw_cost=$(result_field total_cost_usd)
+num_turns=$(result_field num_turns)
+final_msg=$(result_field result)
+
+emit() { printf '%s\n' "$1" >>"$summary"; }
+
+emit_quote() {
+  if [[ -z "$final_msg" ]]; then
+    emit "> _No final message — the run produced no result output._"
+    return
+  fi
+  while IFS= read -r line; do
+    emit "> ${line}"
+  done <<<"$final_msg"
+}
+
+# `gh` wrapper that never aborts the script.
+gh_q() { gh "$@" 2>/dev/null || true; }
+
+round_line() {
+  case "$round" in
+    fix)     echo "Fix round${1:+ $1}" ;;
+    initial) echo "Initial implementation" ;;
+    *)       echo "" ;;
+  esac
+}
+
+emit "## $phase run"
+emit ""
+
+case "$phase" in
+  Coder)
+    title=$(gh_q issue view "$issue" --repo "$repo" --json title --jq .title)
+    emit "**Issue:** [#$issue](${GITHUB_SERVER_URL}/${repo}/issues/${issue})${title:+ — $title}"
+
+    fix_n=""
+    last_flagged_sha=""
+    if [[ "$round" == "fix" && -n "$pr" ]]; then
+      fix_n=$(gh_q api "repos/$repo/pulls/$pr/reviews" \
+        --jq '[.[] | select(.state=="CHANGES_REQUESTED")] | length')
+      last_flagged_sha=$(gh_q api "repos/$repo/pulls/$pr/reviews" \
+        --jq '[.[] | select(.state=="CHANGES_REQUESTED")] | last | .commit_id // empty')
+    fi
+    rl=$(round_line "$fix_n")
+    [[ -n "$rl" ]] && emit "**Round:** $rl"
+
+    # `pr` only resolves an already-open PR — for a fix round it says nothing
+    # about whether this run pushed anything. Treat it as "updated" only when
+    # the head has moved off the commit the reviewer flagged; otherwise the
+    # run failed silently after the PR already existed (AC: show the block).
+    if [[ -z "$pr" ]]; then
+      emit "**Outcome:** ⚠️ No PR — see the final message below."
+    elif [[ "$round" == "fix" ]]; then
+      head_sha=$(gh_q pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid)
+      if [[ -n "$head_sha" && -n "$last_flagged_sha" && "$head_sha" != "$last_flagged_sha" ]]; then
+        emit "**Outcome:** PR updated — [#$pr](${GITHUB_SERVER_URL}/${repo}/pull/${pr})"
+      else
+        emit "**Outcome:** ⚠️ No new commit pushed — see the final message below."
+      fi
+    else
+      emit "**Outcome:** PR opened — [#$pr](${GITHUB_SERVER_URL}/${repo}/pull/${pr})"
+    fi
+
+    if [[ -n "$pr" ]]; then
+      if names=$(gh pr diff "$pr" --repo "$repo" --name-only 2>/dev/null); then
+        emit "**Files changed:** $(printf '%s\n' "$names" | grep -c . || true)"
+      else
+        emit "**Files changed:** unknown"
+      fi
+    fi
+    ;;
+
+  Review)
+    title=$(gh_q pr view "$pr" --repo "$repo" --json title --jq .title)
+    emit "**PR:** [#$pr](${GITHUB_SERVER_URL}/${repo}/pull/${pr})${title:+ — $title}"
+
+    # This run's own verdict is already POSTed by the time we get here, so
+    # count only CHANGES_REQUESTED reviews against *earlier* commits — a
+    # review against the current head is this run's and isn't a prior round.
+    head_sha=$(gh_q pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid)
+    rc_count=$(gh_q api "repos/$repo/pulls/$pr/reviews" \
+      --jq "[.[] | select(.user.login==\"${REVIEWER_BOT:-}\" and .state==\"CHANGES_REQUESTED\" and .commit_id != \"${head_sha}\")] | length")
+    if [[ -n "$rc_count" && "$rc_count" -gt 0 ]]; then
+      emit "**Round:** re-review (after $rc_count changes-requested)"
+    else
+      emit "**Round:** initial review"
+    fi
+
+    # A verdict is this run's outcome only if it was submitted against the PR's
+    # current head — otherwise it's a stale review from an earlier round and
+    # this run submitted nothing (same headRefOid check as the Dedup step).
+    last_state=$(gh_q api "repos/$repo/pulls/$pr/reviews" \
+      --jq "[.[] | select(.user.login==\"${REVIEWER_BOT:-}\")] | last | .state // empty")
+    last_sha=$(gh_q api "repos/$repo/pulls/$pr/reviews" \
+      --jq "[.[] | select(.user.login==\"${REVIEWER_BOT:-}\")] | last | .commit_id // empty")
+    if [[ -n "$head_sha" && -n "$last_sha" && "$head_sha" == "$last_sha" ]]; then
+      case "$last_state" in
+        APPROVED)          emit "**Outcome:** ✅ Approved" ;;
+        CHANGES_REQUESTED) emit "**Outcome:** 🔴 Changes requested" ;;
+        *)                 emit "**Outcome:** ⚠️ No verdict submitted — see the final message below." ;;
+      esac
+    else
+      emit "**Outcome:** ⚠️ No verdict submitted — see the final message below."
+    fi
+    ;;
+
+  Refinement)
+    title=$(gh_q issue view "$issue" --repo "$repo" --json title --jq .title)
+    emit "**Issue:** [#$issue](${GITHUB_SERVER_URL}/${repo}/issues/${issue})${title:+ — $title}"
+
+    labels=",$(gh_q issue view "$issue" --repo "$repo" --json labels --jq '[.labels[].name] | join(",")'),"
+    if [[ "$labels" == *",status:refined,"* ]]; then
+      emit "**Outcome:** Body refined"
+    elif [[ "$labels" == *",status:needs-attention,"* ]]; then
+      emit "**Outcome:** ⚠️ Stopped for clarification — see the final message below."
+    else
+      emit "**Outcome:** ⚠️ Ended without a terminal state — see the final message below."
+    fi
+    ;;
+
+  Estimation)
+    title=$(gh_q issue view "$issue" --repo "$repo" --json title --jq .title)
+    emit "**Issue:** [#$issue](${GITHUB_SERVER_URL}/${repo}/issues/${issue})${title:+ — $title}"
+
+    labels=",$(gh_q issue view "$issue" --repo "$repo" --json labels --jq '[.labels[].name] | join(",")'),"
+    size=$(sed -nE 's/.*,(size:[A-Z]+),.*/\1/p' <<<"$labels")
+    if [[ -n "$size" ]]; then
+      emit "**Outcome:** Estimate posted — \`$size\`"
+    elif [[ "$labels" == *",status:needs-attention,"* ]]; then
+      emit "**Outcome:** ⚠️ Stopped for clarification — see the final message below."
+    else
+      emit "**Outcome:** ⚠️ Ended without an estimate — see the final message below."
+    fi
+    ;;
+
+  *)
+    echo "run-summary: unknown phase $phase" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -f "$exec_file" ]]; then
+  emit ""
+  emit "> _No execution file — the agent step was killed (timed out) before writing results._"
+fi
+
+cost_line="**Cost:** \$$(format_cost "$raw_cost")"
+[[ -n "$num_turns" ]] && cost_line+=" · ${num_turns} turns"
+emit "$cost_line"
+
+if [[ -n "$raw_cost" && -n "$cost_warn" ]] \
+  && awk -v c="$raw_cost" -v w="$cost_warn" 'BEGIN { exit !(c + 0 > w + 0) }'; then
+  emit ""
+  emit "⚠️ cost \$$(format_cost "$raw_cost") over the \$$(printf '%.2f' "$cost_warn") warn limit"
+fi
+
+emit "[Full run log]($(run_url))"
+emit ""
+emit "### Agent's final message"
+emit ""
+emit_quote

--- a/.github/scripts/pipeline/tests/agent-config.bats
+++ b/.github/scripts/pipeline/tests/agent-config.bats
@@ -1,0 +1,102 @@
+setup() {
+  load helpers
+  setup_stubs
+  CONFIG="$BATS_TEST_TMPDIR/agent-pipeline.yml"
+  export AGENT_PIPELINE_CONFIG="$CONFIG"
+  cat >"$CONFIG" <<'EOF'
+defaults:
+  model: claude-sonnet-5
+  max_turns: 40
+  timeout_minutes: 30
+  max_output_tokens: 32000
+  cost_warn_usd: 1.50
+agents:
+  refiner: { model: claude-haiku-4-5-20251001, max_turns: 15 }
+  coder:   { max_turns: 60, timeout_minutes: 45 }
+EOF
+}
+
+out() { grep "^$1=" "$GITHUB_OUTPUT" | cut -d= -f2-; }
+
+@test "agent override wins over defaults" {
+  run "$PIPELINE_DIR/agent-config.sh" coder
+  [ "$status" -eq 0 ]
+  [ "$(out max_turns)" = "60" ]
+  [ "$(out timeout_minutes)" = "45" ]
+}
+
+@test "unset agent key falls back to defaults" {
+  run "$PIPELINE_DIR/agent-config.sh" coder
+  [ "$(out model)" = "claude-sonnet-5" ]
+  [ "$(out max_output_tokens)" = "32000" ]
+}
+
+@test "missing config file falls back to built-in defaults" {
+  export AGENT_PIPELINE_CONFIG="$BATS_TEST_TMPDIR/none.yml"
+  run "$PIPELINE_DIR/agent-config.sh" reviewer
+  [ "$status" -eq 0 ]
+  [ "$(out model)" = "claude-sonnet-5" ]
+  [ "$(out max_turns)" = "40" ]
+}
+
+@test "Actions var is the middle layer between file and built-in" {
+  export AGENT_PIPELINE_CONFIG="$BATS_TEST_TMPDIR/none.yml"
+  PIPELINE_MODEL=my-model run "$PIPELINE_DIR/agent-config.sh" reviewer
+  [ "$(out model)" = "my-model" ]
+}
+
+@test "file value beats the Actions var" {
+  PIPELINE_MODEL=my-model run "$PIPELINE_DIR/agent-config.sh" refiner
+  [ "$(out model)" = "claude-haiku-4-5-20251001" ]
+}
+
+@test "rejects an unknown agent argument" {
+  run "$PIPELINE_DIR/agent-config.sh" tester
+  [ "$status" -ne 0 ]
+}
+
+@test "rejects an unknown top-level key" {
+  echo "junk: 1" >>"$CONFIG"
+  run "$PIPELINE_DIR/agent-config.sh" coder
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown top-level key 'junk'"* ]]
+}
+
+@test "rejects an unknown agent block" {
+  printf '  tester: { max_turns: 5 }\n' >>"$CONFIG"
+  run "$PIPELINE_DIR/agent-config.sh" coder
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown agent 'tester'"* ]]
+}
+
+@test "rejects an unknown limit key" {
+  cat >"$CONFIG" <<'EOF'
+defaults: { max_tokens: 100 }
+EOF
+  run "$PIPELINE_DIR/agent-config.sh" coder
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown key 'defaults.max_tokens'"* ]]
+}
+
+@test "rejects a malformed file" {
+  printf 'defaults: [1\n' >"$CONFIG"
+  run "$PIPELINE_DIR/agent-config.sh" coder
+  [ "$status" -ne 0 ]
+}
+
+@test "rejects max_output_tokens below the floor" {
+  cat >"$CONFIG" <<'EOF'
+defaults: { max_output_tokens: 8000 }
+EOF
+  run "$PIPELINE_DIR/agent-config.sh" coder
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"safety ceiling"* ]]
+}
+
+@test "rejects a non-positive cost_warn_usd" {
+  cat >"$CONFIG" <<'EOF'
+defaults: { cost_warn_usd: 0 }
+EOF
+  run "$PIPELINE_DIR/agent-config.sh" coder
+  [ "$status" -ne 0 ]
+}

--- a/.github/scripts/pipeline/tests/apply-verdict.bats
+++ b/.github/scripts/pipeline/tests/apply-verdict.bats
@@ -1,0 +1,40 @@
+setup() {
+  load helpers
+  setup_stubs
+  export REVIEWER_BOT="reviewer[bot]"
+}
+
+@test "APPROVED clears the pr label and tells the issue" {
+  export STUB_LAST_STATE=APPROVED STUB_PR_LABELS="pr:in-review"
+  run "$PIPELINE_DIR/apply-verdict.sh" 12 34
+  [ "$status" -eq 0 ]
+  grep -q 'gh pr edit 12 --repo owner/repo --remove-label pr:in-review' "$STUB_LOG"
+  grep -q 'gh issue comment 34 .* Reviewer approved \[PR #12\](https://github.com/owner/repo/pull/12) — awaiting owner merge' "$STUB_LOG"
+}
+
+@test "first CHANGES_REQUESTED with a linked issue dispatches a fix round" {
+  export STUB_LAST_STATE=CHANGES_REQUESTED STUB_RC_COUNT=1 STUB_PR_LABELS="pr:in-review"
+  run "$PIPELINE_DIR/apply-verdict.sh" 12 34
+  grep -q 'gh pr edit 12 --repo owner/repo --add-label pr:coding --remove-label pr:in-review' "$STUB_LOG"
+  grep -q 'gh workflow run code-pipeline.yml --repo owner/repo --field phase=coder --field issue_number=34 --field fix_round=true' "$STUB_LOG"
+}
+
+@test "second CHANGES_REQUESTED escalates and does not dispatch" {
+  export STUB_LAST_STATE=CHANGES_REQUESTED STUB_RC_COUNT=2
+  run "$PIPELINE_DIR/apply-verdict.sh" 12 34
+  grep -q "didn't converge. Escalating to a human" "$STUB_LOG"
+  ! grep -q 'gh workflow run' "$STUB_LOG"
+}
+
+@test "CHANGES_REQUESTED with no linked issue can't dispatch" {
+  export STUB_LAST_STATE=CHANGES_REQUESTED STUB_RC_COUNT=1
+  run "$PIPELINE_DIR/apply-verdict.sh" 12 ""
+  grep -q "no linked issue" "$STUB_LOG"
+  ! grep -q 'gh workflow run' "$STUB_LOG"
+}
+
+@test "an unrecognized verdict flags for a human" {
+  export STUB_LAST_STATE=""
+  run "$PIPELINE_DIR/apply-verdict.sh" 12 34
+  grep -q "without submitting a recognized verdict" "$STUB_LOG"
+}

--- a/.github/scripts/pipeline/tests/flag-failure.bats
+++ b/.github/scripts/pipeline/tests/flag-failure.bats
@@ -1,0 +1,35 @@
+setup() {
+  load helpers
+  setup_stubs
+}
+
+@test "standard failure: needs-attention on the issue plus a comment" {
+  export STUB_ISSUE_LABELS="status:in-progress"
+  run "$PIPELINE_DIR/flag-failure.sh" --noun implementation --issue 9
+  [ "$status" -eq 0 ]
+  grep -q 'gh issue edit 9 --repo owner/repo --add-label status:needs-attention --remove-label status:in-progress' "$STUB_LOG"
+  grep -q 'gh issue comment 9 .* Automated implementation failed. See the run: https://github.com/owner/repo/actions/runs/42' "$STUB_LOG"
+}
+
+@test "review failure comments on the PR, not the issue" {
+  run "$PIPELINE_DIR/flag-failure.sh" --noun review --pr 4 --issue 9
+  grep -q 'gh pr comment 4 .* Automated review failed' "$STUB_LOG"
+  ! grep -q 'gh issue comment' "$STUB_LOG"
+}
+
+@test "fix-round failure posts the re-dispatch command on the issue" {
+  run "$PIPELINE_DIR/flag-failure.sh" --noun implementation --issue 9 --pr 4 --fix-round
+  grep -q 'gh issue comment 9 .*gh workflow run code-pipeline.yml -f phase=coder -f issue_number=9 -f fix_round=true' "$STUB_LOG"
+  ! grep -q 'Automated implementation failed' "$STUB_LOG"
+}
+
+@test "an empty --issue is treated as absent" {
+  run "$PIPELINE_DIR/flag-failure.sh" --noun review --pr 4 --issue ""
+  [ "$status" -eq 0 ]
+  ! grep -q 'gh issue' "$STUB_LOG"
+}
+
+@test "rejects an unknown argument" {
+  run "$PIPELINE_DIR/flag-failure.sh" --noun review --wat
+  [ "$status" -eq 1 ]
+}

--- a/.github/scripts/pipeline/tests/gather-fix-feedback.bats
+++ b/.github/scripts/pipeline/tests/gather-fix-feedback.bats
@@ -1,0 +1,28 @@
+setup() {
+  load helpers
+  setup_stubs
+}
+
+@test "errors when no PR number is given" {
+  run "$PIPELINE_DIR/gather-fix-feedback.sh" "" some-branch 5
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no open PR references issue #5"* ]]
+}
+
+@test "errors when there is no CHANGES_REQUESTED review" {
+  export STUB_LAST_STATE=""
+  run "$PIPELINE_DIR/gather-fix-feedback.sh" 6 feature-x 5
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no CHANGES_REQUESTED review found"* ]]
+}
+
+@test "checks out the branch and writes a feedback block to GITHUB_OUTPUT" {
+  export STUB_LAST_STATE='{"id":123,"submitted_at":"2026-01-02T03:04:05Z","body":"do the thing"}'
+  run "$PIPELINE_DIR/gather-fix-feedback.sh" 6 feature-x 5
+  [ "$status" -eq 0 ]
+  grep -q 'git fetch origin feature-x' "$STUB_LOG"
+  grep -q 'git checkout feature-x' "$STUB_LOG"
+  grep -qx 'text<<EOF_FEEDBACK' "$GITHUB_OUTPUT"
+  grep -q 'Latest REQUEST_CHANGES review — 2026-01-02T03:04:05Z' "$GITHUB_OUTPUT"
+  grep -qx 'EOF_FEEDBACK' "$GITHUB_OUTPUT"
+}

--- a/.github/scripts/pipeline/tests/handoff-to-review.bats
+++ b/.github/scripts/pipeline/tests/handoff-to-review.bats
@@ -1,0 +1,19 @@
+setup() {
+  load helpers
+  setup_stubs
+}
+
+@test "hands the PR to the reviewer when one exists" {
+  export STUB_PR_LABELS="pr:coding"
+  run "$PIPELINE_DIR/handoff-to-review.sh" 7 15
+  [ "$status" -eq 0 ]
+  grep -q 'gh pr edit 15 --repo owner/repo --remove-label pr:coding --add-label pr:in-review' "$STUB_LOG"
+  ! grep -q 'gh issue' "$STUB_LOG"
+}
+
+@test "flags the issue when the coder left no PR" {
+  export STUB_ISSUE_LABELS="status:in-progress"
+  run "$PIPELINE_DIR/handoff-to-review.sh" 7 ""
+  grep -q 'gh issue edit 7 --repo owner/repo --add-label status:needs-attention --remove-label status:in-progress' "$STUB_LOG"
+  grep -q 'gh issue comment 7 .* without leaving an open PR referencing this issue' "$STUB_LOG"
+}

--- a/.github/scripts/pipeline/tests/helpers.bash
+++ b/.github/scripts/pipeline/tests/helpers.bash
@@ -1,0 +1,67 @@
+# Test helpers: a PATH-shadowing `gh` (and `git`) stub that logs every
+# invocation to $STUB_LOG and returns canned output driven by STUB_* env vars.
+
+PIPELINE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+setup_stubs() {
+  STUB_BIN="$BATS_TEST_TMPDIR/bin"
+  STUB_LOG="$BATS_TEST_TMPDIR/calls.log"
+  mkdir -p "$STUB_BIN"
+  : >"$STUB_LOG"
+
+  cat >"$STUB_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"$STUB_LOG"
+case "$1 $2" in
+  "issue view")
+    case "$*" in
+      *--json\ title*) echo "${STUB_ISSUE_TITLE-}" ;;
+      *) echo "${STUB_ISSUE_LABELS-}" ;;
+    esac ;;
+  "pr view")
+    case "$*" in
+      *headRefOid*) echo "${STUB_HEAD_SHA-}" ;;
+      *--json\ title*) echo "${STUB_PR_TITLE-}" ;;
+      *) echo "${STUB_PR_LABELS-}" ;;
+    esac ;;
+  "pr checks") echo "${STUB_PR_CHECKS-[]}" ;;
+  "pr diff") echo "${STUB_PR_FILES-}" ;;
+esac
+case "$1" in
+  api)
+    if [[ "$*" == *"/reviews"* && -n "${STUB_REVIEWS-}" ]]; then
+      # Faithful path: run the real --jq expression against a reviews fixture.
+      jqexpr=; shift
+      while [[ $# -gt 0 ]]; do [[ "$1" == "--jq" ]] && { jqexpr="$2"; break; }; shift; done
+      jq -r "$jqexpr" <<<"$STUB_REVIEWS"
+    else
+      case "$*" in
+        *"| length"*) echo "${STUB_RC_COUNT-0}" ;;
+        *commit_id*) echo "${STUB_LAST_SHA-}" ;;
+        *) echo "${STUB_LAST_STATE-}" ;;
+      esac
+    fi ;;
+esac
+exit "${STUB_GH_EXIT-0}"
+EOF
+
+  cat >"$STUB_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "git $*" >>"$STUB_LOG"
+exit 0
+EOF
+
+  chmod +x "$STUB_BIN/gh" "$STUB_BIN/git"
+  PATH="$STUB_BIN:$PATH"
+
+  export STUB_LOG
+  export GITHUB_REPOSITORY="owner/repo"
+  export GITHUB_SERVER_URL="https://github.com"
+  export GITHUB_RUN_ID="42"
+  export GITHUB_EVENT_NAME="pull_request"
+  export GH_TOKEN="x"
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output"
+  : >"$GITHUB_OUTPUT"
+}
+
+calls() { cat "$STUB_LOG"; }

--- a/.github/scripts/pipeline/tests/lib.bats
+++ b/.github/scripts/pipeline/tests/lib.bats
@@ -1,0 +1,55 @@
+setup() {
+  load helpers
+  setup_stubs
+  source "$PIPELINE_DIR/lib.sh"
+}
+
+@test "run_url builds the workflow run URL from the env" {
+  run run_url
+  [ "$status" -eq 0 ]
+  [ "$output" = "https://github.com/owner/repo/actions/runs/42" ]
+}
+
+@test "format_cost rounds to 4 decimals" {
+  run format_cost 0.123456
+  [ "$output" = "0.1235" ]
+}
+
+@test "format_cost returns unknown for an empty value" {
+  run format_cost ""
+  [ "$output" = "unknown" ]
+}
+
+@test "set_issue_status adds the target and removes only present lifecycle labels" {
+  export STUB_ISSUE_LABELS="type:bug,status:in-progress"
+  run set_issue_status 7 status:needs-attention
+  [ "$status" -eq 0 ]
+  grep -qF -- "gh issue edit 7 --repo owner/repo --add-label status:needs-attention --remove-label status:in-progress" "$STUB_LOG"
+  ! grep -qF -- "--remove-label status:ready" "$STUB_LOG"
+}
+
+@test "set_issue_status on an issue with no lifecycle label just adds the target" {
+  export STUB_ISSUE_LABELS="status:needs-refinement"
+  run set_issue_status 7 status:needs-attention
+  grep -qF -- "gh issue edit 7 --repo owner/repo --add-label status:needs-attention" "$STUB_LOG"
+  ! grep -qF -- "--remove-label" "$STUB_LOG"
+}
+
+@test "set_pr_pipeline_label with no target clears the present pr label" {
+  export STUB_PR_LABELS="pr:in-review,size:S"
+  run set_pr_pipeline_label 3
+  grep -qF -- "gh pr edit 3 --repo owner/repo --remove-label pr:in-review" "$STUB_LOG"
+}
+
+@test "set_pr_pipeline_label swaps to the target label" {
+  export STUB_PR_LABELS="pr:in-review"
+  run set_pr_pipeline_label 3 pr:coding
+  grep -qF -- "gh pr edit 3 --repo owner/repo --add-label pr:coding --remove-label pr:in-review" "$STUB_LOG"
+}
+
+@test "set_pr_pipeline_label is a no-op when nothing changes" {
+  export STUB_PR_LABELS="size:S"
+  run set_pr_pipeline_label 3
+  [ "$status" -eq 0 ]
+  ! grep -q "gh pr edit" "$STUB_LOG"
+}

--- a/.github/scripts/pipeline/tests/report-run.bats
+++ b/.github/scripts/pipeline/tests/report-run.bats
@@ -1,0 +1,31 @@
+setup() {
+  load helpers
+  setup_stubs
+}
+
+@test "comments on the issue with the parsed cost" {
+  echo '[{"type":"result","total_cost_usd":0.42}]' >"$BATS_TEST_TMPDIR/exec.json"
+  run "$PIPELINE_DIR/report-run.sh" Coder "$BATS_TEST_TMPDIR/exec.json" 55
+  [ "$status" -eq 0 ]
+  grep -q 'gh issue comment 55 --repo owner/repo --body Coder \[pipeline run\](https://github.com/owner/repo/actions/runs/42) — cost: \$0.4200' "$STUB_LOG"
+}
+
+@test "falls back to the PR only when the issue number is empty" {
+  echo '[{"type":"result","total_cost_usd":1}]' >"$BATS_TEST_TMPDIR/exec.json"
+  run "$PIPELINE_DIR/report-run.sh" Review "$BATS_TEST_TMPDIR/exec.json" "" 88
+  [ "$status" -eq 0 ]
+  grep -q 'gh pr comment 88 ' "$STUB_LOG"
+  ! grep -q 'gh issue comment' "$STUB_LOG"
+}
+
+@test "missing execution file yields an unknown cost" {
+  run "$PIPELINE_DIR/report-run.sh" Coder /no/such/file 55
+  [ "$status" -eq 0 ]
+  grep -q 'cost: \$unknown' "$STUB_LOG"
+}
+
+@test "errors when given neither an issue nor a PR" {
+  echo '[]' >"$BATS_TEST_TMPDIR/exec.json"
+  run "$PIPELINE_DIR/report-run.sh" Coder "$BATS_TEST_TMPDIR/exec.json" "" ""
+  [ "$status" -eq 1 ]
+}

--- a/.github/scripts/pipeline/tests/route-red-checks.bats
+++ b/.github/scripts/pipeline/tests/route-red-checks.bats
@@ -1,0 +1,19 @@
+setup() {
+  load helpers
+  setup_stubs
+}
+
+@test "clears the pr label, comments, and flags the linked issue" {
+  export STUB_PR_LABELS="pr:in-review" STUB_ISSUE_LABELS="status:in-progress"
+  run "$PIPELINE_DIR/route-red-checks.sh" 8 19 '`test`=fail, `build`=pass'
+  [ "$status" -eq 0 ]
+  grep -q 'gh pr edit 8 --repo owner/repo --remove-label pr:in-review' "$STUB_LOG"
+  grep -q 'gh pr comment 8 .* Required checks are not green (`test`=fail, `build`=pass)' "$STUB_LOG"
+  grep -q 'gh issue edit 19 --repo owner/repo --add-label status:needs-attention --remove-label status:in-progress' "$STUB_LOG"
+}
+
+@test "skips the issue edit when there is no linked issue" {
+  run "$PIPELINE_DIR/route-red-checks.sh" 8 "" 'timed out'
+  [ "$status" -eq 0 ]
+  ! grep -q 'gh issue' "$STUB_LOG"
+}

--- a/.github/scripts/pipeline/tests/run-summary.bats
+++ b/.github/scripts/pipeline/tests/run-summary.bats
@@ -1,0 +1,186 @@
+setup() {
+  load helpers
+  setup_stubs
+  export GITHUB_STEP_SUMMARY="$BATS_TEST_TMPDIR/summary.md"
+  : >"$GITHUB_STEP_SUMMARY"
+  EXEC="$BATS_TEST_TMPDIR/exec.json"
+}
+
+summary() { cat "$GITHUB_STEP_SUMMARY"; }
+
+@test "coder: issue, round, PR outcome, files, cost, final message" {
+  echo '[{"type":"result","total_cost_usd":0.5,"num_turns":7,"result":"All steps done, opening the PR."}]' >"$EXEC"
+  export STUB_ISSUE_TITLE="Add a widget"
+  export STUB_PR_FILES=$'src/a.ts\nsrc/b.ts\nsrc/c.ts'
+  run "$PIPELINE_DIR/run-summary.sh" Coder "$EXEC" --issue 42 --pr 99 --round initial
+  [ "$status" -eq 0 ]
+  summary | grep -qF '## Coder run'
+  summary | grep -qF '**Issue:** [#42](https://github.com/owner/repo/issues/42) — Add a widget'
+  summary | grep -qF '**Round:** Initial implementation'
+  summary | grep -qF '**Outcome:** PR opened — [#99](https://github.com/owner/repo/pull/99)'
+  summary | grep -qF '**Files changed:** 3'
+  summary | grep -qF '**Cost:** $0.5000 · 7 turns'
+  summary | grep -qF '> All steps done, opening the PR.'
+  ! summary | grep -qi 'checks'
+}
+
+@test "coder: a failed diff lookup reads 'unknown', not '0'" {
+  echo '[{"type":"result","result":"done"}]' >"$EXEC"
+  export STUB_GH_EXIT=1
+  run "$PIPELINE_DIR/run-summary.sh" Coder "$EXEC" --issue 42 --pr 99 --round initial
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**Files changed:** unknown'
+}
+
+@test "coder: no PR opened surfaces a blocked outcome without the log" {
+  echo '[{"type":"result","result":"Could not push the branch: missing workflows permission."}]' >"$EXEC"
+  run "$PIPELINE_DIR/run-summary.sh" Coder "$EXEC" --issue 42 --round initial
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**Outcome:** ⚠️ No PR — see the final message below.'
+  summary | grep -qF '> Could not push the branch: missing workflows permission.'
+  ! summary | grep -q 'Files changed'
+}
+
+@test "coder: fix round that pushed a new commit shows PR updated" {
+  echo '[{"type":"result"}]' >"$EXEC"
+  export STUB_RC_COUNT=2
+  export STUB_LAST_SHA="oldsha"
+  export STUB_HEAD_SHA="newsha"
+  run "$PIPELINE_DIR/run-summary.sh" Coder "$EXEC" --issue 42 --pr 99 --round fix
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**Round:** Fix round 2'
+  summary | grep -qF '**Outcome:** PR updated — [#99](https://github.com/owner/repo/pull/99)'
+}
+
+@test "coder: fix round that pushed nothing shows the blocked outcome" {
+  echo '[{"type":"result","result":"Could not push: guarded path."}]' >"$EXEC"
+  export STUB_RC_COUNT=1
+  export STUB_LAST_SHA="samesha"
+  export STUB_HEAD_SHA="samesha"
+  run "$PIPELINE_DIR/run-summary.sh" Coder "$EXEC" --issue 42 --pr 99 --round fix
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**Outcome:** ⚠️ No new commit pushed — see the final message below.'
+  summary | grep -qF '> Could not push: guarded path.'
+}
+
+@test "review: approved verdict" {
+  echo '[{"type":"result","total_cost_usd":0.1,"result":"Looks good, approving."}]' >"$EXEC"
+  export STUB_PR_TITLE="feat: widget"
+  export STUB_LAST_STATE="APPROVED"
+  export STUB_RC_COUNT=0
+  export STUB_HEAD_SHA="headsha"
+  export STUB_LAST_SHA="headsha"
+  export REVIEWER_BOT="prepify-reviewer[bot]"
+  run "$PIPELINE_DIR/run-summary.sh" Review "$EXEC" --pr 99 --issue 42
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**PR:** [#99](https://github.com/owner/repo/pull/99) — feat: widget'
+  summary | grep -qF '**Round:** initial review'
+  summary | grep -qF '**Outcome:** ✅ Approved'
+  summary | grep -qF '> Looks good, approving.'
+}
+
+@test "review: no verdict submitted" {
+  echo '[{"type":"result","result":"Could not use the review tool, posting here."}]' >"$EXEC"
+  export STUB_LAST_STATE=""
+  export STUB_RC_COUNT=1
+  export STUB_HEAD_SHA="headsha"
+  export STUB_LAST_SHA=""
+  run "$PIPELINE_DIR/run-summary.sh" Review "$EXEC" --pr 99
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**Round:** re-review (after 1 changes-requested)'
+  summary | grep -qF '**Outcome:** ⚠️ No verdict submitted — see the final message below.'
+}
+
+@test "review: a PR's first-ever review requesting changes is 'initial', not 're-review'" {
+  echo '[{"type":"result","result":"Requesting changes."}]' >"$EXEC"
+  export REVIEWER_BOT="prepify-reviewer[bot]"
+  export STUB_HEAD_SHA="head1"
+  export STUB_REVIEWS='[{"user":{"login":"prepify-reviewer[bot]"},"state":"CHANGES_REQUESTED","commit_id":"head1"}]'
+  run "$PIPELINE_DIR/run-summary.sh" Review "$EXEC" --pr 99
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**Round:** initial review'
+  summary | grep -qF '**Outcome:** 🔴 Changes requested'
+}
+
+@test "review: a genuine re-review counts only prior-commit changes-requested" {
+  echo '[{"type":"result","result":"Still not there."}]' >"$EXEC"
+  export REVIEWER_BOT="prepify-reviewer[bot]"
+  export STUB_HEAD_SHA="head2"
+  export STUB_REVIEWS='[{"user":{"login":"prepify-reviewer[bot]"},"state":"CHANGES_REQUESTED","commit_id":"head1"},{"user":{"login":"prepify-reviewer[bot]"},"state":"CHANGES_REQUESTED","commit_id":"head2"}]'
+  run "$PIPELINE_DIR/run-summary.sh" Review "$EXEC" --pr 99
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**Round:** re-review (after 1 changes-requested)'
+  summary | grep -qF '**Outcome:** 🔴 Changes requested'
+}
+
+@test "review: a stale verdict against an old commit is not counted as this run's" {
+  echo '[{"type":"result","result":"Stopped early."}]' >"$EXEC"
+  export STUB_LAST_STATE="CHANGES_REQUESTED"
+  export STUB_RC_COUNT=1
+  export STUB_HEAD_SHA="newsha"
+  export STUB_LAST_SHA="oldsha"
+  run "$PIPELINE_DIR/run-summary.sh" Review "$EXEC" --pr 99
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**Outcome:** ⚠️ No verdict submitted — see the final message below.'
+}
+
+@test "refinement: body refined" {
+  echo '[{"type":"result","total_cost_usd":0.02,"result":"Rewrote the body."}]' >"$EXEC"
+  export STUB_ISSUE_TITLE="Vague idea"
+  export STUB_ISSUE_LABELS="type:coding-task,status:refined"
+  run "$PIPELINE_DIR/run-summary.sh" Refinement "$EXEC" --issue 7
+  [ "$status" -eq 0 ]
+  summary | grep -qF '## Refinement run'
+  summary | grep -qF '**Outcome:** Body refined'
+}
+
+@test "refinement: stopped for clarification" {
+  echo '[{"type":"result","result":"Need to know which API."}]' >"$EXEC"
+  export STUB_ISSUE_LABELS="status:needs-attention"
+  run "$PIPELINE_DIR/run-summary.sh" Refinement "$EXEC" --issue 7
+  summary | grep -qF '**Outcome:** ⚠️ Stopped for clarification — see the final message below.'
+}
+
+@test "estimation: estimate posted with size label" {
+  echo '[{"type":"result","total_cost_usd":0.03,"result":"SIZE: M"}]' >"$EXEC"
+  export STUB_ISSUE_LABELS="type:coding-task,status:estimated,size:M"
+  run "$PIPELINE_DIR/run-summary.sh" Estimation "$EXEC" --issue 7
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**Outcome:** Estimate posted — `size:M`'
+}
+
+@test "missing execution file yields an unknown cost and a placeholder message" {
+  run "$PIPELINE_DIR/run-summary.sh" Refinement /no/such/file --issue 7
+  [ "$status" -eq 0 ]
+  summary | grep -qF '**Cost:** $unknown'
+  summary | grep -qF '> _No final message — the run produced no result output._'
+}
+
+@test "cost over the warn limit adds a warning line" {
+  echo '[{"type":"result","total_cost_usd":2.5,"result":"done"}]' >"$EXEC"
+  export STUB_ISSUE_LABELS="status:refined"
+  run "$PIPELINE_DIR/run-summary.sh" Refinement "$EXEC" --issue 7 --cost-warn 0.30
+  [ "$status" -eq 0 ]
+  summary | grep -qF '⚠️ cost $2.5000 over the $0.30 warn limit'
+}
+
+@test "cost under the warn limit adds no warning line" {
+  echo '[{"type":"result","total_cost_usd":0.10,"result":"done"}]' >"$EXEC"
+  export STUB_ISSUE_LABELS="status:refined"
+  run "$PIPELINE_DIR/run-summary.sh" Refinement "$EXEC" --issue 7 --cost-warn 0.30
+  [ "$status" -eq 0 ]
+  ! summary | grep -q 'warn limit'
+}
+
+@test "missing execution file reports a timeout" {
+  export STUB_ISSUE_LABELS="status:in-progress"
+  run "$PIPELINE_DIR/run-summary.sh" Refinement "" --issue 7 --cost-warn 0.30
+  [ "$status" -eq 0 ]
+  summary | grep -qF 'killed (timed out) before writing results'
+}
+
+@test "errors on an unknown phase" {
+  echo '[]' >"$EXEC"
+  run "$PIPELINE_DIR/run-summary.sh" Bogus "$EXEC" --issue 7
+  [ "$status" -eq 1 ]
+}

--- a/.github/scripts/pipeline/tests/run-summary.bats
+++ b/.github/scripts/pipeline/tests/run-summary.bats
@@ -70,7 +70,7 @@ summary() { cat "$GITHUB_STEP_SUMMARY"; }
   export STUB_RC_COUNT=0
   export STUB_HEAD_SHA="headsha"
   export STUB_LAST_SHA="headsha"
-  export REVIEWER_BOT="prepify-reviewer[bot]"
+  export REVIEWER_BOT="reviewer-app[bot]"
   run "$PIPELINE_DIR/run-summary.sh" Review "$EXEC" --pr 99 --issue 42
   [ "$status" -eq 0 ]
   summary | grep -qF '**PR:** [#99](https://github.com/owner/repo/pull/99) — feat: widget'
@@ -93,9 +93,9 @@ summary() { cat "$GITHUB_STEP_SUMMARY"; }
 
 @test "review: a PR's first-ever review requesting changes is 'initial', not 're-review'" {
   echo '[{"type":"result","result":"Requesting changes."}]' >"$EXEC"
-  export REVIEWER_BOT="prepify-reviewer[bot]"
+  export REVIEWER_BOT="reviewer-app[bot]"
   export STUB_HEAD_SHA="head1"
-  export STUB_REVIEWS='[{"user":{"login":"prepify-reviewer[bot]"},"state":"CHANGES_REQUESTED","commit_id":"head1"}]'
+  export STUB_REVIEWS='[{"user":{"login":"reviewer-app[bot]"},"state":"CHANGES_REQUESTED","commit_id":"head1"}]'
   run "$PIPELINE_DIR/run-summary.sh" Review "$EXEC" --pr 99
   [ "$status" -eq 0 ]
   summary | grep -qF '**Round:** initial review'
@@ -104,9 +104,9 @@ summary() { cat "$GITHUB_STEP_SUMMARY"; }
 
 @test "review: a genuine re-review counts only prior-commit changes-requested" {
   echo '[{"type":"result","result":"Still not there."}]' >"$EXEC"
-  export REVIEWER_BOT="prepify-reviewer[bot]"
+  export REVIEWER_BOT="reviewer-app[bot]"
   export STUB_HEAD_SHA="head2"
-  export STUB_REVIEWS='[{"user":{"login":"prepify-reviewer[bot]"},"state":"CHANGES_REQUESTED","commit_id":"head1"},{"user":{"login":"prepify-reviewer[bot]"},"state":"CHANGES_REQUESTED","commit_id":"head2"}]'
+  export STUB_REVIEWS='[{"user":{"login":"reviewer-app[bot]"},"state":"CHANGES_REQUESTED","commit_id":"head1"},{"user":{"login":"reviewer-app[bot]"},"state":"CHANGES_REQUESTED","commit_id":"head2"}]'
   run "$PIPELINE_DIR/run-summary.sh" Review "$EXEC" --pr 99
   [ "$status" -eq 0 ]
   summary | grep -qF '**Round:** re-review (after 1 changes-requested)'

--- a/.github/scripts/pipeline/tests/verify-outcome.bats
+++ b/.github/scripts/pipeline/tests/verify-outcome.bats
@@ -1,0 +1,30 @@
+setup() {
+  load helpers
+  setup_stubs
+}
+
+@test "no-op when the issue already carries an expected label" {
+  export STUB_ISSUE_LABELS="type:bug,status:refined"
+  run "$PIPELINE_DIR/verify-outcome.sh" Refinement 3 status:refined status:needs-attention
+  [ "$status" -eq 0 ]
+  ! grep -q 'gh issue comment' "$STUB_LOG"
+  ! grep -q 'gh issue edit' "$STUB_LOG"
+}
+
+@test "two expected labels render as 'a or b'" {
+  export STUB_ISSUE_LABELS="status:needs-refinement"
+  run "$PIPELINE_DIR/verify-outcome.sh" Refinement 3 status:refined status:needs-attention
+  grep -q 'gh issue comment 3 .* Refinement run completed without leaving the issue in `status:refined` or `status:needs-attention` — likely stopped partway through. See the run: https://github.com/owner/repo/actions/runs/42' "$STUB_LOG"
+}
+
+@test "three expected labels use an Oxford comma" {
+  export STUB_ISSUE_LABELS="status:estimated-wrong"
+  run "$PIPELINE_DIR/verify-outcome.sh" Estimation 3 status:estimated status:ready status:needs-attention
+  grep -q '`status:estimated`, `status:ready`, or `status:needs-attention`' "$STUB_LOG"
+}
+
+@test "flags the issue for a human when no expected label is present" {
+  export STUB_ISSUE_LABELS="status:needs-refinement"
+  run "$PIPELINE_DIR/verify-outcome.sh" Refinement 3 status:refined status:needs-attention
+  grep -q 'gh issue edit 3 --repo owner/repo --add-label status:needs-attention' "$STUB_LOG"
+}

--- a/.github/scripts/pipeline/tests/wait-for-checks.bats
+++ b/.github/scripts/pipeline/tests/wait-for-checks.bats
@@ -1,0 +1,35 @@
+setup() {
+  load helpers
+  setup_stubs
+}
+
+@test "workflow_dispatch skips the gate" {
+  export GITHUB_EVENT_NAME=workflow_dispatch
+  run "$PIPELINE_DIR/wait-for-checks.sh" ""
+  [ "$status" -eq 0 ]
+  grep -qx 'ok=true' "$GITHUB_OUTPUT"
+}
+
+@test "both checks passing -> ok=true" {
+  export STUB_PR_CHECKS='[{"name":"test","bucket":"pass"},{"name":"build","bucket":"pass"}]'
+  run "$PIPELINE_DIR/wait-for-checks.sh" 5
+  [ "$status" -eq 0 ]
+  grep -qx 'ok=true' "$GITHUB_OUTPUT"
+}
+
+@test "a failing check -> ok=false with a reason" {
+  export STUB_PR_CHECKS='[{"name":"test","bucket":"fail"},{"name":"build","bucket":"pass"}]'
+  run "$PIPELINE_DIR/wait-for-checks.sh" 5
+  [ "$status" -eq 0 ]
+  grep -qx 'ok=false' "$GITHUB_OUTPUT"
+  grep -qx 'reason=`test`=fail, `build`=pass' "$GITHUB_OUTPUT"
+}
+
+@test "times out when a check never resolves" {
+  export STUB_PR_CHECKS='[{"name":"test","bucket":"pending"},{"name":"build","bucket":"pending"}]'
+  export CHECK_TIMEOUT_SECONDS=0
+  run "$PIPELINE_DIR/wait-for-checks.sh" 5
+  [ "$status" -eq 0 ]
+  grep -qx 'ok=false' "$GITHUB_OUTPUT"
+  grep -q 'reason=timed out' "$GITHUB_OUTPUT"
+}

--- a/.github/scripts/pipeline/verify-outcome.sh
+++ b/.github/scripts/pipeline/verify-outcome.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Backstop for an issue-pipeline phase that exited 0 without leaving the issue
+# in one of its expected terminal states — the agent stopped partway. Flags the
+# issue for a human and says so in a comment. A no-op when the issue already
+# carries an expected label.
+#
+# Usage: verify-outcome.sh <phase> <issue> <expected-label>...
+#   e.g. verify-outcome.sh Refinement 42 status:refined status:needs-attention
+
+set -euo pipefail
+# shellcheck source=.github/scripts/pipeline/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+phase="$1"
+issue="$2"
+shift 2
+expected=("$@")
+
+current=$(gh issue view "$issue" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")')
+for label in "${expected[@]}"; do
+  if [[ ",$current," == *",$label,"* ]]; then
+    exit 0
+  fi
+done
+
+# "`a`, `b`, or `c`" — the human-readable list for the comment.
+human=""
+last=$((${#expected[@]} - 1))
+for i in "${!expected[@]}"; do
+  if [[ "$i" -eq 0 ]]; then
+    sep=""
+  elif [[ "$i" -eq "$last" && "${#expected[@]}" -eq 2 ]]; then
+    sep=" or "
+  elif [[ "$i" -eq "$last" ]]; then
+    sep=", or "
+  else
+    sep=", "
+  fi
+  human+="${sep}\`${expected[$i]}\`"
+done
+
+set_issue_status "$issue" status:needs-attention
+gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body \
+  "$phase run completed without leaving the issue in $human — likely stopped partway through. See the run: $(run_url)"

--- a/.github/scripts/pipeline/wait-for-checks.sh
+++ b/.github/scripts/pipeline/wait-for-checks.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Reviewer gate. The `test` and `build` checks (deploy.yml) are the single
+# source of truth for "is it green" — the reviewer no longer runs them itself
+# (#134). Waits for both to finish, then writes `ok` (and `reason` when not ok)
+# to $GITHUB_OUTPUT. A red check routes to a human, no coder retry loop (#133).
+# A manual workflow_dispatch review is an explicit override and skips the gate.
+#
+# Usage: wait-for-checks.sh <pr-number>
+#   Env knobs (defaults match CI): CHECK_TIMEOUT_SECONDS=1200, CHECK_POLL_SECONDS=20
+
+set -euo pipefail
+
+PR="$1"
+REPO="$GITHUB_REPOSITORY"
+TIMEOUT="${CHECK_TIMEOUT_SECONDS:-1200}"
+POLL="${CHECK_POLL_SECONDS:-20}"
+
+if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+  echo "Manual dispatch — skipping the check gate."
+  echo "ok=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+DEADLINE=$((SECONDS + TIMEOUT))
+while [ "$SECONDS" -lt "$DEADLINE" ]; do
+  JSON=$(gh pr checks "$PR" --repo "$REPO" --json name,bucket 2>/dev/null || echo '[]')
+  TEST=$(jq -r '[.[] | select(.name=="test")] | .[0].bucket // "missing"' <<<"$JSON")
+  BUILD=$(jq -r '[.[] | select(.name=="build")] | .[0].bucket // "missing"' <<<"$JSON")
+  echo "test=$TEST build=$BUILD"
+  if [[ "$TEST" == "fail" || "$TEST" == "cancel" || "$BUILD" == "fail" || "$BUILD" == "cancel" ]]; then
+    echo "ok=false" >> "$GITHUB_OUTPUT"
+    echo "reason=\`test\`=$TEST, \`build\`=$BUILD" >> "$GITHUB_OUTPUT"
+    exit 0
+  fi
+  if [[ ( "$TEST" == "pass" || "$TEST" == "skipping" ) && ( "$BUILD" == "pass" || "$BUILD" == "skipping" ) ]]; then
+    echo "ok=true" >> "$GITHUB_OUTPUT"
+    exit 0
+  fi
+  sleep "$POLL"
+done
+echo "ok=false" >> "$GITHUB_OUTPUT"
+echo "reason=timed out waiting for the \`test\` / \`build\` checks to complete" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/code-pipeline.yml
+++ b/.github/workflows/code-pipeline.yml
@@ -1,0 +1,513 @@
+name: Coding agents (reusable)
+
+# Reusable core of the coder/reviewer pipeline. Triggered only via
+# code-pipeline.yml, which owns the `issues` / `pull_request` /
+# `workflow_dispatch` triggers and passes its dispatch inputs through.
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        description: Issue number (coder phase, workflow_dispatch only)
+        required: false
+        type: string
+      pr_number:
+        description: PR number (reviewer phase, workflow_dispatch only)
+        required: false
+        type: string
+      fix_round:
+        description: Treat a coder dispatch as a reviewer fix round
+        required: false
+        type: boolean
+        default: false
+      phase:
+        description: coder | reviewer (workflow_dispatch only)
+        required: false
+        type: string
+      debug:
+        description: Show full Claude output in logs
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: OAuth token for anthropics/claude-code-action
+        required: true
+      REVIEWER_APP_PRIVATE_KEY:
+        description: Private key for the reviewer GitHub App (paired with vars.REVIEWER_APP_ID); reviewer job only
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+env:
+  # Bash perms are literal-prefix matched, so each gh-safe script is listed in every path form the agent might type (#104).
+  ALLOWED_COMMENT_ISSUE: "Bash(./.interns/.github/scripts/gh-safe/comment-issue.sh:*),Bash(.interns/.github/scripts/gh-safe/comment-issue.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/comment-issue.sh:*)"
+  ALLOWED_COMMENT_PR: "Bash(./.interns/.github/scripts/gh-safe/comment-pr.sh:*),Bash(.interns/.github/scripts/gh-safe/comment-pr.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/comment-pr.sh:*)"
+  ALLOWED_OPEN_PR: "Bash(./.interns/.github/scripts/gh-safe/open-pr.sh:*),Bash(.interns/.github/scripts/gh-safe/open-pr.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/open-pr.sh:*)"
+  ALLOWED_SUBMIT_REVIEW: "Bash(./.interns/.github/scripts/gh-safe/submit-pr-review.sh:*),Bash(.interns/.github/scripts/gh-safe/submit-pr-review.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/submit-pr-review.sh:*)"
+  ALLOWED_PUSH_BRANCH: "Bash(./.interns/.github/scripts/gh-safe/push-branch.sh:*),Bash(.interns/.github/scripts/gh-safe/push-branch.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/push-branch.sh:*)"
+  # In-sandbox git only. git push is deliberately absent — reaching the shared remote goes through push-branch.sh.
+  ALLOWED_GIT_WRITE: "Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git rm:*)"
+  ALLOWED_GIT_READ: "Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*)"
+  ALLOWED_BUILD_TEST: "Bash(npm install:*),Bash(npm ci:*),Bash(npm test:*),Bash(npm run build:*)"
+  ALLOWED_CI_READ: "Bash(gh pr checks:*),Bash(gh run view:*)"
+  ALLOWED_ISSUE_READ: "Bash(gh issue view:*)"
+
+jobs:
+  coder:
+    if: >
+      (github.event_name == 'issues' && github.event.label.name == 'status:ready') ||
+      (github.event_name == 'workflow_dispatch' && inputs.phase == 'coder')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: coder-issue-${{ github.event.issue.number || inputs.issue_number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve pipeline ref
+        id: pipeline_ref
+        shell: bash
+        env:
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+        run: echo "ref=${JOB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pipeline assets
+        uses: actions/checkout@v5
+        with:
+          repository: abi83/interns
+          ref: ${{ steps.pipeline_ref.outputs.ref }}
+          path: .interns
+
+      # vars.WIKI_REPO — repo-level Actions variable pointing at a wiki repo, or unset.
+      - name: Checkout wiki
+        if: vars.WIKI_REPO != ''
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ vars.WIKI_REPO }}
+          path: wiki
+
+      - name: Resolve issue
+        id: issue
+        uses: ./.interns/.github/actions/resolve-issue
+        with:
+          issue_number: ${{ github.event.issue.number || inputs.issue_number }}
+
+      - name: Guard against duplicate or stale trigger
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          NUM="${{ steps.issue.outputs.number }}"
+          FIX_ROUND="${{ inputs.fix_round }}"
+          LABELS=$(gh issue view "$NUM" --repo ${{ github.repository }} --json labels --jq '[.labels[].name] | join(",")')
+          echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
+          echo "fix_round=$FIX_ROUND" >> "$GITHUB_OUTPUT"
+          # A fix round is an explicit dispatch from the reviewer against an issue
+          # that is *already* status:in-progress — the stale-trigger guard below
+          # would wrongly skip it, so let it through.
+          if [[ "$FIX_ROUND" != "true" ]] && \
+             [[ "$LABELS" == *"status:in-progress"* || "$LABELS" == *"status:needs-attention"* ]]; then
+            echo "Issue #$NUM is already past status:ready ($LABELS) — stale or duplicate trigger, skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$LABELS" != *"type:coding-task"* && "$LABELS" != *"type:bug"* ]]; then
+            # Deterministic type gate: only type:coding-task and type:bug are
+            # implementable. status:ready can also land on an epic (via its
+            # estimate-phase bypass) or a spike, neither of which the coder
+            # should ever attempt — see #112.
+            echo "Issue #$NUM is not type:coding-task or type:bug ($LABELS) — not implementable, escalating."
+            gh issue edit "$NUM" --repo ${{ github.repository }} \
+              --add-label "status:needs-attention" --remove-label "status:ready"
+            gh issue comment "$NUM" --repo ${{ github.repository }} --body "This issue reached \`status:ready\` without a \`type:coding-task\` or \`type:bug\` label, so the coder agent won't attempt it — only those two types are implementable code deliverables. If this should be implemented, add the correct type label and re-apply \`status:ready\`."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine fix round
+        id: mode
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          # The reviewer dispatches a fix round explicitly with
+          # `-f fix_round=true`; an initial `status:ready` label event never
+          # sets it. No label-derived inference — issue state no longer
+          # distinguishes the two (the issue stays status:in-progress for
+          # the whole run).
+          if [[ "${{ steps.guard.outputs.fix_round }}" == "true" ]]; then
+            echo "fix_round=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fix_round=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set in-progress
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Also clears status:needs-attention so a human re-dispatch after a
+          # failed run (initial or fix round) leaves no contradictory labels.
+          gh issue edit "${{ steps.issue.outputs.number }}" --repo ${{ github.repository }} \
+            --add-label "status:in-progress" \
+            --remove-label "status:ready" --remove-label "status:needs-attention" || true
+
+      - name: Resolve agent config
+        id: cfg
+        if: steps.guard.outputs.skip != 'true'
+        uses: ./.interns/.github/actions/resolve-agent-config
+        with:
+          agent: coder
+          pipeline_model: ${{ vars.PIPELINE_MODEL }}
+          pipeline_max_turns: ${{ vars.PIPELINE_MAX_TURNS }}
+          pipeline_timeout_minutes: ${{ vars.PIPELINE_TIMEOUT_MINUTES }}
+          pipeline_max_output_tokens: ${{ vars.PIPELINE_MAX_OUTPUT_TOKENS }}
+          pipeline_cost_warn_usd: ${{ vars.PIPELINE_COST_WARN_USD }}
+
+      - name: Resolve existing PR (fix round)
+        id: pr
+        if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.fix_round == 'true'
+        uses: ./.interns/.github/actions/find-pr-for-issue
+        with:
+          issue_number: ${{ steps.issue.outputs.number }}
+
+      - name: Mark PR pr:coding (fix round)
+        if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.fix_round == 'true' && steps.pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ steps.pr.outputs.pr_number }}" --repo ${{ github.repository }} \
+            --add-label "pr:coding" --remove-label "pr:in-review" || true
+
+      - name: Gather reviewer feedback (fix round)
+        id: feedback
+        if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.fix_round == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          .interns/.github/scripts/pipeline/gather-fix-feedback.sh
+          "${{ steps.pr.outputs.pr_number }}"
+          "${{ steps.pr.outputs.head_ref }}"
+          "${{ steps.issue.outputs.number }}"
+
+      - name: Run Claude coder (initial implementation)
+        id: claude_initial
+        if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.fix_round != 'true'
+        timeout-minutes: ${{ fromJSON(steps.cfg.outputs.timeout_minutes) }}
+        uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: ${{ steps.cfg.outputs.max_output_tokens }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: ${{ inputs.debug }}
+          allowed_bots: "claude[bot]"
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ steps.issue.outputs.number }}
+            TITLE: ${{ steps.issue.outputs.title }}
+            OWNER: @${{ github.repository_owner }}
+            BODY:
+            ${{ steps.issue.outputs.body }}
+
+            ${{ steps.issue.outputs.comments }}
+
+            Read .interns/.github/prompts/code.md for the exact implementation and
+            PR-opening rules and apply them to the issue above.
+          claude_args: |
+            --model ${{ steps.cfg.outputs.model }}
+            --max-turns ${{ steps.cfg.outputs.max_turns }}
+            --allowedTools "Read,Grep,Glob,Write,Edit,${{ env.ALLOWED_GIT_WRITE }},${{ env.ALLOWED_PUSH_BRANCH }},${{ env.ALLOWED_BUILD_TEST }},${{ env.ALLOWED_OPEN_PR }},${{ env.ALLOWED_COMMENT_ISSUE }}"
+
+      - name: Run Claude coder (fix round)
+        id: claude_fix
+        if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.fix_round == 'true'
+        timeout-minutes: ${{ fromJSON(steps.cfg.outputs.timeout_minutes) }}
+        uses: anthropics/claude-code-action@v1
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: ${{ steps.cfg.outputs.max_output_tokens }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: ${{ inputs.debug }}
+          # The fix round is dispatched by the reviewer job via `gh workflow run`
+          # with the default token, so the triggering actor is github-actions[bot],
+          # not a human label event — claude-code-action refuses it unless the bot
+          # is allowlisted here. The initial-implementation step doesn't need this:
+          # it's triggered by a real `status:ready` label event on the issue.
+          allowed_bots: "claude[bot],github-actions[bot]"
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ steps.issue.outputs.number }}
+            TITLE: ${{ steps.issue.outputs.title }}
+            PR NUMBER: ${{ steps.pr.outputs.pr_number }}
+            BRANCH: ${{ steps.pr.outputs.head_ref }} (already checked out)
+
+            REVIEWER FEEDBACK:
+            ${{ steps.feedback.outputs.text }}
+
+            Read .interns/.github/prompts/code-fix.md for the exact rules and
+            apply them to the feedback above.
+          claude_args: |
+            --model ${{ steps.cfg.outputs.model }}
+            --max-turns ${{ steps.cfg.outputs.max_turns }}
+            --allowedTools "Read,Grep,Glob,Write,Edit,${{ env.ALLOWED_GIT_WRITE }},${{ env.ALLOWED_PUSH_BRANCH }},${{ env.ALLOWED_BUILD_TEST }},${{ env.ALLOWED_COMMENT_PR }}"
+
+      - name: Report run cost
+        if: steps.guard.outputs.skip != 'true' && always() && (steps.claude_initial.outputs.execution_file != '' || steps.claude_fix.outputs.execution_file != '')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          .interns/.github/scripts/pipeline/report-run.sh Coder
+          "${{ steps.claude_initial.outputs.execution_file }}${{ steps.claude_fix.outputs.execution_file }}"
+          "${{ steps.issue.outputs.number }}"
+
+      - name: Check PR now exists
+        id: verify_pr
+        if: steps.guard.outputs.skip != 'true' && success()
+        uses: ./.interns/.github/actions/find-pr-for-issue
+        with:
+          issue_number: ${{ steps.issue.outputs.number }}
+
+      - name: Hand off to reviewer
+        if: steps.guard.outputs.skip != 'true' && success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          .interns/.github/scripts/pipeline/handoff-to-review.sh
+          "${{ steps.issue.outputs.number }}" "${{ steps.verify_pr.outputs.pr_number }}"
+
+      - name: Write run summary
+        if: steps.guard.outputs.skip != 'true' && always() && (steps.claude_initial.outcome != 'skipped' || steps.claude_fix.outcome != 'skipped')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          .interns/.github/scripts/pipeline/run-summary.sh Coder
+          "${{ steps.claude_initial.outputs.execution_file }}${{ steps.claude_fix.outputs.execution_file }}"
+          --issue "${{ steps.issue.outputs.number }}"
+          --pr "${{ steps.verify_pr.outputs.pr_number || steps.pr.outputs.pr_number }}"
+          --round ${{ steps.mode.outputs.fix_round == 'true' && 'fix' || 'initial' }}
+          --cost-warn "${{ steps.cfg.outputs.cost_warn_usd }}"
+
+      - name: Flag failure
+        if: steps.guard.outputs.skip != 'true' && failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${{ steps.mode.outputs.fix_round }}" == "true" ]]; then
+            .interns/.github/scripts/pipeline/flag-failure.sh --noun implementation \
+              --issue "${{ steps.issue.outputs.number }}" \
+              --pr "${{ steps.pr.outputs.pr_number }}" --fix-round
+          else
+            .interns/.github/scripts/pipeline/flag-failure.sh --noun implementation \
+              --issue "${{ steps.issue.outputs.number }}"
+          fi
+
+  reviewer:
+    # Skip PRs the reviewer can't meaningfully handle instead of failing on them
+    # (see #132 defect 8):
+    #  - fork PRs have no access to secrets, so CLAUDE_CODE_OAUTH_TOKEN /
+    #    REVIEWER_APP_PRIVATE_KEY are empty and the run just errors out;
+    #  - bot PRs other than the coder's claude[bot] (Dependabot, etc.) aren't in
+    #    allowed_bots and produce an "Automated review failed" comment.
+    # A skipped job posts nothing. workflow_dispatch stays an unconditional
+    # manual override.
+    if: >
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork == false &&
+        (github.event.pull_request.user.type != 'Bot' ||
+         github.event.pull_request.user.login == 'claude[bot]')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.phase == 'reviewer')
+    runs-on: ubuntu-latest
+    # GITHUB_TOKEN-authored label edits don't fire new workflow runs (GitHub's
+    # anti-recursion rule for the default token), so a label alone would never
+    # re-trigger the coder job for a fix round. actions: write lets this job
+    # explicitly dispatch it instead (see "Apply verdict" below) — an
+    # intentional workflow_dispatch call, which is exempt from that restriction.
+    # Overriding permissions at job level means every permission this job needs
+    # must be listed here, not just the new one.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: write
+      id-token: write
+    concurrency:
+      group: reviewer-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve pipeline ref
+        id: pipeline_ref
+        shell: bash
+        env:
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+        run: echo "ref=${JOB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pipeline assets
+        uses: actions/checkout@v5
+        with:
+          repository: abi83/interns
+          ref: ${{ steps.pipeline_ref.outputs.ref }}
+          path: .interns
+
+      # vars.WIKI_REPO — repo-level Actions variable pointing at a wiki repo, or unset.
+      - name: Checkout wiki
+        if: vars.WIKI_REPO != ''
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ vars.WIKI_REPO }}
+          path: wiki
+
+      - name: Resolve linked issue
+        id: linked
+        uses: ./.interns/.github/actions/resolve-linked-issue
+        with:
+          pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+
+      - name: Resolve agent config
+        id: cfg
+        uses: ./.interns/.github/actions/resolve-agent-config
+        with:
+          agent: reviewer
+          pipeline_model: ${{ vars.PIPELINE_MODEL }}
+          pipeline_max_turns: ${{ vars.PIPELINE_MAX_TURNS }}
+          pipeline_timeout_minutes: ${{ vars.PIPELINE_TIMEOUT_MINUTES }}
+          pipeline_max_output_tokens: ${{ vars.PIPELINE_MAX_OUTPUT_TOKENS }}
+          pipeline_cost_warn_usd: ${{ vars.PIPELINE_COST_WARN_USD }}
+
+      - name: Wait for test + build checks
+        id: checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: .interns/.github/scripts/pipeline/wait-for-checks.sh "${{ github.event.pull_request.number }}"
+
+      - name: Route red checks to a human
+        if: steps.checks.outputs.ok == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          .interns/.github/scripts/pipeline/route-red-checks.sh
+          "${{ github.event.pull_request.number }}"
+          "${{ steps.linked.outputs.issue_number }}"
+          "${{ steps.checks.outputs.reason }}"
+
+      # The reviewer runs under its own GitHub App identity, distinct from the
+      # coder's claude[bot], so it can actually submit an APPROVE review —
+      # GitHub forbids approving a PR authored by the same identity (#119).
+      - name: Generate reviewer app token
+        id: reviewer_token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.REVIEWER_APP_ID }}
+          private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
+
+      # One source of truth for the reviewer's bot login, derived from the app
+      # token (which is derived from vars.REVIEWER_APP_ID). Every step that
+      # matches reviews by author reads this output — renaming the app only
+      # touches the variable, never a hardcoded slug (see #132 defect 3).
+      - name: Resolve reviewer identity
+        id: ident
+        run: echo "bot=${{ steps.reviewer_token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
+
+      # Dedup only. The round cap lives in "Apply verdict":
+      # the reviewer always runs and submits a verdict (so a second review can
+      # still land on APPROVE), and the escalate-vs-dispatch-coder decision is
+      # made from that verdict — see #132 defect 6.
+      - name: Dedup check
+        id: check
+        if: steps.checks.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEWER_BOT: ${{ steps.ident.outputs.bot }}
+        run: |
+          PR="${{ github.event.pull_request.number || inputs.pr_number }}"
+          HEAD_SHA=$(gh pr view "$PR" --repo ${{ github.repository }} --json headRefOid --jq .headRefOid)
+          LAST_SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR/reviews" \
+            --jq '[.[] | select(.user.login==env.REVIEWER_BOT)] | last | .commit_id // empty')
+
+          if [[ -n "$LAST_SHA" && "$LAST_SHA" == "$HEAD_SHA" ]]; then
+            echo "Head commit $HEAD_SHA already reviewed — duplicate event, skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Claude reviewer
+        id: claude
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true'
+        timeout-minutes: ${{ fromJSON(steps.cfg.outputs.timeout_minutes) }}
+        uses: anthropics/claude-code-action@v1
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: ${{ steps.cfg.outputs.max_output_tokens }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.reviewer_token.outputs.token }}
+          show_full_output: ${{ inputs.debug }}
+          allowed_bots: "claude[bot]"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+            LINKED ISSUE: ${{ steps.linked.outputs.issue_number }}
+
+            Read .interns/.github/prompts/review.md for the exact review rubric
+            and the mechanic for submitting your verdict, and review this
+            PR's diff against the linked issue's Acceptance Criteria.
+          claude_args: |
+            --model ${{ steps.cfg.outputs.model }}
+            --max-turns ${{ steps.cfg.outputs.max_turns }}
+            --allowedTools "Read,Grep,Glob,Write,${{ env.ALLOWED_GIT_READ }},${{ env.ALLOWED_CI_READ }},${{ env.ALLOWED_ISSUE_READ }},${{ env.ALLOWED_SUBMIT_REVIEW }},${{ env.ALLOWED_COMMENT_PR }}"
+
+      - name: Report run cost
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && always() && steps.claude.outputs.execution_file != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          .interns/.github/scripts/pipeline/report-run.sh Review
+          "${{ steps.claude.outputs.execution_file }}"
+          "${{ steps.linked.outputs.issue_number }}"
+          "${{ github.event.pull_request.number || inputs.pr_number }}"
+
+      - name: Apply reviewer verdict
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEWER_BOT: ${{ steps.ident.outputs.bot }}
+        run: >
+          .interns/.github/scripts/pipeline/apply-verdict.sh
+          "${{ github.event.pull_request.number || inputs.pr_number }}"
+          "${{ steps.linked.outputs.issue_number }}"
+
+      - name: Write run summary
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && always() && steps.claude.outcome != 'skipped'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEWER_BOT: ${{ steps.ident.outputs.bot }}
+        run: >
+          .interns/.github/scripts/pipeline/run-summary.sh Review
+          "${{ steps.claude.outputs.execution_file }}"
+          --pr "${{ github.event.pull_request.number || inputs.pr_number }}"
+          --issue "${{ steps.linked.outputs.issue_number }}"
+          --cost-warn "${{ steps.cfg.outputs.cost_warn_usd }}"
+
+      - name: Flag failure
+        # Also fires when Resolve agent config fails — that step runs before
+        # `checks`, so a bad config would otherwise leave checks.outputs.ok
+        # empty and skip the standard failure comment (#150's generic fallback).
+        if: >
+          failure() && (
+            steps.cfg.outcome == 'failure' ||
+            (steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true')
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          .interns/.github/scripts/pipeline/flag-failure.sh --noun review
+          --pr "${{ github.event.pull_request.number || inputs.pr_number }}"
+          --issue "${{ steps.linked.outputs.issue_number }}"

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -1,0 +1,313 @@
+name: Issue pipeline (reusable)
+
+# Reusable core of the issue refine/estimate pipeline. Triggered only via
+# issue-pipeline.yml, which owns the `issues` / `workflow_dispatch` triggers and
+# passes its dispatch inputs through. External repos call this file the same way.
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        description: Issue number (workflow_dispatch path only)
+        required: false
+        type: string
+      phase:
+        description: refine | estimate (workflow_dispatch path only)
+        required: false
+        type: string
+      debug:
+        description: Show full Claude output in logs
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: OAuth token for anthropics/claude-code-action
+        required: true
+
+permissions:
+  issues: write
+  id-token: write
+
+env:
+  # Bash permission matching is a literal prefix match on the command string
+  # (not a resolved path), so each gh-safe script needs an entry for every
+  # form the agent might type it in: relative with ./, relative without it,
+  # and workspace-absolute.
+  ALLOWED_EDIT_BODY: "Bash(./.interns/.github/scripts/gh-safe/edit-issue-body.sh:*),Bash(.interns/.github/scripts/gh-safe/edit-issue-body.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/edit-issue-body.sh:*)"
+  ALLOWED_EDIT_LABELS: "Bash(./.interns/.github/scripts/gh-safe/edit-issue-labels.sh:*),Bash(.interns/.github/scripts/gh-safe/edit-issue-labels.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/edit-issue-labels.sh:*)"
+  ALLOWED_COMMENT: "Bash(./.interns/.github/scripts/gh-safe/comment-issue.sh:*),Bash(.interns/.github/scripts/gh-safe/comment-issue.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/comment-issue.sh:*)"
+
+jobs:
+  refine:
+    if: >
+      github.event.label.name == 'status:needs-refinement' ||
+      (github.event_name == 'workflow_dispatch' && inputs.phase == 'refine')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve pipeline ref
+        id: pipeline_ref
+        shell: bash
+        env:
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+        run: echo "ref=${JOB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pipeline assets
+        uses: actions/checkout@v5
+        with:
+          repository: abi83/interns
+          ref: ${{ steps.pipeline_ref.outputs.ref }}
+          path: .interns
+
+      # vars.WIKI_REPO — repo-level Actions variable, set to a wiki repo, or unset.
+      - name: Checkout wiki
+        if: vars.WIKI_REPO != ''
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ vars.WIKI_REPO }}
+          path: wiki
+
+      - name: Resolve issue
+        id: issue
+        uses: ./.interns/.github/actions/resolve-issue
+        with:
+          issue_number: ${{ github.event.issue.number || inputs.issue_number }}
+
+      - name: Resolve agent config
+        id: cfg
+        uses: ./.interns/.github/actions/resolve-agent-config
+        with:
+          agent: refiner
+          pipeline_model: ${{ vars.PIPELINE_MODEL }}
+          pipeline_max_turns: ${{ vars.PIPELINE_MAX_TURNS }}
+          pipeline_timeout_minutes: ${{ vars.PIPELINE_TIMEOUT_MINUTES }}
+          pipeline_max_output_tokens: ${{ vars.PIPELINE_MAX_OUTPUT_TOKENS }}
+          pipeline_cost_warn_usd: ${{ vars.PIPELINE_COST_WARN_USD }}
+
+      - name: Preserve original body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          ISSUE_BODY: ${{ steps.issue.outputs.body }}
+        run: |
+          printf '<details><summary>Body before refinement</summary>\n\n%s\n\n</details>' "$ISSUE_BODY" \
+            | gh issue comment "$ISSUE_NUMBER" --repo ${{ github.repository }} --body-file -
+
+      - name: Run Claude refinement
+        id: claude
+        timeout-minutes: ${{ fromJSON(steps.cfg.outputs.timeout_minutes) }}
+        uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: ${{ steps.cfg.outputs.max_output_tokens }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: ${{ inputs.debug }}
+          allowed_bots: "claude[bot]"
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ steps.issue.outputs.number }}
+            TITLE: ${{ steps.issue.outputs.title }}
+            OWNER: @${{ github.repository_owner }}
+            BODY:
+            ${{ steps.issue.outputs.body }}
+
+            ${{ steps.issue.outputs.comments }}
+
+            Read .interns/.github/prompts/refine.md for the exact rewrite rules and
+            apply them to the issue and comments above to produce a new
+            body.
+
+            Important: never pass issue body or comment text as a Bash
+            command-line argument — multi-line markdown breaks shell
+            quoting. Instead, use the Write tool to write text to a file
+            first, then run the script with no arguments so it reads
+            that file.
+
+            If refine.md says to stop for clarification:
+            1. Write your question to ./.issue-pipeline-comment.md
+            2. Run ./.interns/.github/scripts/gh-safe/comment-issue.sh (no args)
+            3. Swap labels:
+               ./.interns/.github/scripts/gh-safe/edit-issue-labels.sh --remove-label "status:needs-refinement" --add-label "status:needs-attention"
+            Then stop. Do not edit the body in this case.
+
+            Otherwise, in order:
+            1. Write the new body to ./.issue-pipeline-body.md
+            2. Run ./.interns/.github/scripts/gh-safe/edit-issue-body.sh (no args)
+            3. Swap labels:
+               ./.interns/.github/scripts/gh-safe/edit-issue-labels.sh --remove-label "status:needs-refinement" --add-label "status:refined"
+
+            Do nothing else — no other comments, no other edits.
+          claude_args: |
+            --model ${{ steps.cfg.outputs.model }}
+            --max-turns ${{ steps.cfg.outputs.max_turns }}
+            --allowedTools "Read,Grep,Glob,Write,${{ env.ALLOWED_EDIT_BODY }},${{ env.ALLOWED_EDIT_LABELS }},${{ env.ALLOWED_COMMENT }}"
+
+      - name: Report run cost
+        if: always() && steps.claude.outputs.execution_file != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          .interns/.github/scripts/pipeline/report-run.sh Refinement
+          "${{ steps.claude.outputs.execution_file }}"
+          "${{ steps.issue.outputs.number }}"
+
+      - name: Verify outcome
+        if: success() && steps.claude.outputs.execution_file != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          .interns/.github/scripts/pipeline/verify-outcome.sh Refinement
+          "${{ steps.issue.outputs.number }}"
+          status:refined status:needs-attention
+
+      - name: Write run summary
+        if: always() && steps.claude.outcome != 'skipped'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          .interns/.github/scripts/pipeline/run-summary.sh Refinement
+          "${{ steps.claude.outputs.execution_file }}"
+          --issue "${{ steps.issue.outputs.number }}"
+          --cost-warn "${{ steps.cfg.outputs.cost_warn_usd }}"
+
+      - name: Flag failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          .interns/.github/scripts/pipeline/flag-failure.sh --noun refinement
+          --issue "${{ steps.issue.outputs.number }}"
+
+  estimate:
+    if: >
+      github.event.label.name == 'status:refined' ||
+      (github.event_name == 'workflow_dispatch' && inputs.phase == 'estimate')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve pipeline ref
+        id: pipeline_ref
+        shell: bash
+        env:
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+        run: echo "ref=${JOB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pipeline assets
+        uses: actions/checkout@v5
+        with:
+          repository: abi83/interns
+          ref: ${{ steps.pipeline_ref.outputs.ref }}
+          path: .interns
+
+      - name: Checkout wiki
+        if: vars.WIKI_REPO != ''
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ vars.WIKI_REPO }}
+          path: wiki
+
+      - name: Resolve issue
+        id: issue
+        uses: ./.interns/.github/actions/resolve-issue
+        with:
+          issue_number: ${{ github.event.issue.number || inputs.issue_number }}
+
+      - name: Resolve agent config
+        id: cfg
+        uses: ./.interns/.github/actions/resolve-agent-config
+        with:
+          agent: estimator
+          pipeline_model: ${{ vars.PIPELINE_MODEL }}
+          pipeline_max_turns: ${{ vars.PIPELINE_MAX_TURNS }}
+          pipeline_timeout_minutes: ${{ vars.PIPELINE_TIMEOUT_MINUTES }}
+          pipeline_max_output_tokens: ${{ vars.PIPELINE_MAX_OUTPUT_TOKENS }}
+          pipeline_cost_warn_usd: ${{ vars.PIPELINE_COST_WARN_USD }}
+
+      - name: Run Claude estimation
+        id: claude
+        timeout-minutes: ${{ fromJSON(steps.cfg.outputs.timeout_minutes) }}
+        uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: ${{ steps.cfg.outputs.max_output_tokens }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: ${{ inputs.debug }}
+          allowed_bots: "claude[bot]"
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ steps.issue.outputs.number }}
+            TITLE: ${{ steps.issue.outputs.title }}
+            OWNER: @${{ github.repository_owner }}
+            BODY:
+            ${{ steps.issue.outputs.body }}
+
+            ${{ steps.issue.outputs.comments }}
+
+            Read .interns/.github/prompts/estimate.md for the exact sizing rules and
+            apply them to the refined issue and comments above.
+
+            Important: never pass comment text as a Bash command-line
+            argument — multi-line text breaks shell quoting. Instead, use
+            the Write tool to write text to a file first, then run the
+            script with no arguments so it reads that file.
+
+            If estimate.md says to stop for clarification:
+            1. Write your question to ./.issue-pipeline-comment.md
+            2. Run ./.interns/.github/scripts/gh-safe/comment-issue.sh (no args)
+            3. Swap labels:
+               ./.interns/.github/scripts/gh-safe/edit-issue-labels.sh --remove-label "status:refined" --add-label "status:needs-attention"
+            Then stop.
+
+            Otherwise, in order:
+            1. Write the estimate output (verbatim) to
+               ./.issue-pipeline-comment.md
+            2. Run ./.interns/.github/scripts/gh-safe/comment-issue.sh (no args)
+            3. Add the size label matching your SIZE line (size:XS,
+               size:S, size:M, size:L, or size:XL) and swap status:
+               ./.interns/.github/scripts/gh-safe/edit-issue-labels.sh --remove-label "status:refined" --add-label "status:estimated" --add-label "size:<SIZE>"
+
+            Do nothing else.
+          claude_args: |
+            --model ${{ steps.cfg.outputs.model }}
+            --max-turns ${{ steps.cfg.outputs.max_turns }}
+            --allowedTools "Read,Grep,Glob,Write,${{ env.ALLOWED_COMMENT }},${{ env.ALLOWED_EDIT_LABELS }}"
+
+      - name: Report run cost
+        if: always() && steps.claude.outputs.execution_file != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          .interns/.github/scripts/pipeline/report-run.sh Estimation
+          "${{ steps.claude.outputs.execution_file }}"
+          "${{ steps.issue.outputs.number }}"
+
+      - name: Verify outcome
+        if: success() && steps.claude.outputs.execution_file != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          .interns/.github/scripts/pipeline/verify-outcome.sh Estimation
+          "${{ steps.issue.outputs.number }}"
+          status:estimated status:ready status:needs-attention
+
+      - name: Write run summary
+        if: always() && steps.claude.outcome != 'skipped'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          .interns/.github/scripts/pipeline/run-summary.sh Estimation
+          "${{ steps.claude.outputs.execution_file }}"
+          --issue "${{ steps.issue.outputs.number }}"
+          --cost-warn "${{ steps.cfg.outputs.cost_warn_usd }}"
+
+      - name: Flag failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          .interns/.github/scripts/pipeline/flag-failure.sh --noun estimation
+          --issue "${{ steps.issue.outputs.number }}"

--- a/.github/workflows/lint-pipeline.yml
+++ b/.github/workflows/lint-pipeline.yml
@@ -1,0 +1,41 @@
+name: Lint pipeline
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Lint workflows and their inline run blocks
+        # docker://rhysd/actionlint:1.7.12, pinned by digest.
+        # -ignore '\.interns': the reusable workflows reference their own composite
+        #   actions under ./.interns/... — a path that only exists at runtime, once
+        #   the job self-checks-out this repo there (see code-pipeline.yml).
+        # -ignore 'job_workflow_ref': a valid context property this actionlint
+        #   version doesn't know yet.
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        with:
+          args: -color -ignore '\.interns' -ignore 'job_workflow_ref'
+
+      # -x so shellcheck follows the `source` of pipeline/lib.sh.
+      - name: Lint standalone shell scripts
+        run: find .github/scripts -name '*.sh' -print0 | xargs -0 -r shellcheck -x
+
+      - name: Validate the agent-pipeline schema is well-formed
+        run: pipx run check-jsonschema --check-metaschema .github/agent-pipeline.schema.json
+
+  test-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run pipeline script tests
+        run: bats .github/scripts/pipeline/tests

--- a/.github/workflows/lint-pipeline.yml
+++ b/.github/workflows/lint-pipeline.yml
@@ -22,7 +22,7 @@ jobs:
         #   version doesn't know yet.
         uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
         with:
-          args: -color -ignore '\.interns' -ignore 'job_workflow_ref'
+          args: -color -ignore interns -ignore job_workflow_ref
 
       # -x so shellcheck follows the `source` of pipeline/lib.sh.
       - name: Lint standalone shell scripts

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# interns
+
+A tireless team of interns that refine issues, estimate them, open PRs, and
+review each other's work — while a human stays in the loop on every merge.
+
+The pipeline drives [Claude Code](https://github.com/anthropics/claude-code) over
+a checked-out repo and respects its `CLAUDE.md` / `AGENTS.md`. It runs entirely
+in the consumer repo's GitHub Actions — no hosted service, no webhook receiver.
+
+Tracking issue: [abi83/prepify#130](https://github.com/abi83/prepify/issues/130).
+
+## What's here
+
+| Path | |
+|---|---|
+| `.github/workflows/issue-pipeline.yml` | reusable `workflow_call` core — refine + estimate |
+| `.github/workflows/code-pipeline.yml` | reusable `workflow_call` core — coder + reviewer |
+| `.github/actions/*` | composite actions the cores use |
+| `.github/scripts/pipeline/*` | pipeline shell steps (+ `bats` tests) |
+| `.github/scripts/gh-safe/*` | the narrow `gh` surface the agents are allowed to call |
+| `.github/prompts/*` | the agent prompts, layered over the consumer's `CLAUDE.md` |
+| `.github/agent-pipeline.schema.json` | schema for the consumer's `.github/agent-pipeline.yml` |
+
+Each reusable job self-checks-out this repo at its own tag into `.interns/` and
+runs the assets from there, so a consumer never vendors any of it.
+
+## Consuming it
+
+Commit two thin caller workflows to your repo. They own the triggers and
+delegate everything else:
+
+```yaml
+# .github/workflows/issue-pipeline.yml
+name: Issue Refinement & Estimation
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number: { description: Issue number, required: true }
+      phase: { description: refine | estimate, required: true, type: choice, options: [refine, estimate] }
+permissions:
+  issues: write
+  id-token: write
+jobs:
+  pipeline:
+    uses: abi83/interns/.github/workflows/issue-pipeline.yml@v0.1.0
+    secrets: inherit
+    with:
+      issue_number: ${{ inputs.issue_number }}
+      phase: ${{ inputs.phase }}
+```
+
+```yaml
+# .github/workflows/code-pipeline.yml
+name: Coding Agents
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      phase: { description: coder | reviewer, required: true, type: choice, options: [coder, reviewer] }
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: write
+  id-token: write
+jobs:
+  pipeline:
+    uses: abi83/interns/.github/workflows/code-pipeline.yml@v0.1.0
+    secrets: inherit
+    with:
+      phase: ${{ inputs.phase }}
+```
+
+Pin an **exact** tag, not a moving `@v0` — the job self-checks-out its assets at
+the same ref, and a moving major tag would let the two drift.
+
+### Required in the consumer repo
+
+- Secrets: `CLAUDE_CODE_OAUTH_TOKEN`; `REVIEWER_APP_PRIVATE_KEY` for the reviewer
+- Variable: `REVIEWER_APP_ID` (the reviewer runs as its own GitHub App so it can
+  approve the coder's PRs)
+- The `status:*` / `type:*` / `size:*` label set the state machine moves between
+- Default-branch protection — the agents commit through PRs only
+
+### Optional
+
+- `.github/agent-pipeline.yml` — per-agent model and execution limits
+  (precedence: this file > `PIPELINE_*` Actions vars > built-in defaults)
+- Variable `WIKI_REPO` — a wiki repo to check out alongside the code
+
+An installer that provisions the labels, caller stubs, and safety checks is
+tracked separately ([#153](https://github.com/abi83/prepify/issues/153),
+[#154](https://github.com/abi83/prepify/issues/154)).
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Optional: `.github/agent-pipeline.yml` (per-agent model + limits).
 A one-shot installer that provisions all of that is tracked in
 [abi83/prepify#153](https://github.com/abi83/prepify/issues/153) /
 [#154](https://github.com/abi83/prepify/issues/154). A fuller README —
-pipeline flow, label state table — is tracked separately.
+pipeline flow, label state table — is [abi83/prepify#163](https://github.com/abi83/prepify/issues/163).
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -1,101 +1,58 @@
 # interns
 
 A tireless team of interns that refine issues, estimate them, open PRs, and
-review each other's work — while a human stays in the loop on every merge.
+review each other's work — with a human in the loop on every merge.
 
-The pipeline drives [Claude Code](https://github.com/anthropics/claude-code) over
-a checked-out repo and respects its `CLAUDE.md` / `AGENTS.md`. It runs entirely
-in the consumer repo's GitHub Actions — no hosted service, no webhook receiver.
+The pipeline drives [Claude Code](https://github.com/anthropics/claude-code)
+over a checked-out repo, respects its `CLAUDE.md` / `AGENTS.md`, and runs
+entirely in the consumer repo's GitHub Actions — no hosted service.
 
-Tracking issue: [abi83/prepify#130](https://github.com/abi83/prepify/issues/130).
-
-## What's here
-
-| Path | |
-|---|---|
-| `.github/workflows/issue-pipeline.yml` | reusable `workflow_call` core — refine + estimate |
-| `.github/workflows/code-pipeline.yml` | reusable `workflow_call` core — coder + reviewer |
-| `.github/actions/*` | composite actions the cores use |
-| `.github/scripts/pipeline/*` | pipeline shell steps (+ `bats` tests) |
-| `.github/scripts/gh-safe/*` | the narrow `gh` surface the agents are allowed to call |
-| `.github/prompts/*` | the agent prompts, layered over the consumer's `CLAUDE.md` |
-| `.github/agent-pipeline.schema.json` | schema for the consumer's `.github/agent-pipeline.yml` |
-
-Each reusable job self-checks-out this repo at its own tag into `.interns/` and
-runs the assets from there, so a consumer never vendors any of it.
+Status: early. Consumed by [`abi83/prepify`](https://github.com/abi83/prepify).
+Design and roadmap: [abi83/prepify#130](https://github.com/abi83/prepify/issues/130).
 
 ## Consuming it
 
-Commit two thin caller workflows to your repo. They own the triggers and
-delegate everything else:
+Commit two thin caller workflows that own the triggers and delegate to the
+reusable cores, pinned to an exact tag:
 
 ```yaml
 # .github/workflows/issue-pipeline.yml
-name: Issue Refinement & Estimation
-on:
-  issues:
-    types: [labeled]
-  workflow_dispatch:
-    inputs:
-      issue_number: { description: Issue number, required: true }
-      phase: { description: refine | estimate, required: true, type: choice, options: [refine, estimate] }
-permissions:
-  issues: write
-  id-token: write
 jobs:
   pipeline:
     uses: abi83/interns/.github/workflows/issue-pipeline.yml@v0.1.0
     secrets: inherit
-    with:
-      issue_number: ${{ inputs.issue_number }}
-      phase: ${{ inputs.phase }}
+    with: { phase: ${{ inputs.phase }} }
 ```
 
 ```yaml
 # .github/workflows/code-pipeline.yml
-name: Coding Agents
-on:
-  issues:
-    types: [labeled]
-  pull_request:
-    types: [opened, synchronize, reopened]
-  workflow_dispatch:
-    inputs:
-      phase: { description: coder | reviewer, required: true, type: choice, options: [coder, reviewer] }
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  actions: write
-  id-token: write
 jobs:
   pipeline:
     uses: abi83/interns/.github/workflows/code-pipeline.yml@v0.1.0
     secrets: inherit
-    with:
-      phase: ${{ inputs.phase }}
+    with: { phase: ${{ inputs.phase }} }
 ```
 
-Pin an **exact** tag, not a moving `@v0` — the job self-checks-out its assets at
-the same ref, and a moving major tag would let the two drift.
+Needs, in the consumer repo: `CLAUDE_CODE_OAUTH_TOKEN` +
+`REVIEWER_APP_PRIVATE_KEY` secrets, a `REVIEWER_APP_ID` var, the
+`status:*` / `type:*` / `size:*` labels, and default-branch protection.
+Optional: `.github/agent-pipeline.yml` (per-agent model + limits).
 
-### Required in the consumer repo
+A one-shot installer that provisions all of that is tracked in
+[abi83/prepify#153](https://github.com/abi83/prepify/issues/153) /
+[#154](https://github.com/abi83/prepify/issues/154). A fuller README —
+pipeline flow, label state table — is tracked separately.
 
-- Secrets: `CLAUDE_CODE_OAUTH_TOKEN`; `REVIEWER_APP_PRIVATE_KEY` for the reviewer
-- Variable: `REVIEWER_APP_ID` (the reviewer runs as its own GitHub App so it can
-  approve the coder's PRs)
-- The `status:*` / `type:*` / `size:*` label set the state machine moves between
-- Default-branch protection — the agents commit through PRs only
+## Layout
 
-### Optional
-
-- `.github/agent-pipeline.yml` — per-agent model and execution limits
-  (precedence: this file > `PIPELINE_*` Actions vars > built-in defaults)
-- Variable `WIKI_REPO` — a wiki repo to check out alongside the code
-
-An installer that provisions the labels, caller stubs, and safety checks is
-tracked separately ([#153](https://github.com/abi83/prepify/issues/153),
-[#154](https://github.com/abi83/prepify/issues/154)).
+| | |
+|---|---|
+| `.github/workflows/*-pipeline.yml` | reusable `workflow_call` cores |
+| `.github/actions/*` | composite actions the cores use |
+| `.github/scripts/pipeline/*` | pipeline steps (+ `bats` tests) |
+| `.github/scripts/gh-safe/*` | the narrow `gh` surface the agents may call |
+| `.github/prompts/*` | agent prompts, layered over the consumer's `CLAUDE.md` |
+| `templates/issue/*` | default issue templates |
 
 ## License
 

--- a/templates/issue/bug.md
+++ b/templates/issue/bug.md
@@ -1,0 +1,24 @@
+---
+name: Bug
+about: Something is broken — behavior diverges from what's expected.
+title: "fix: "
+labels: type:bug
+---
+
+## Description
+
+<!-- What's wrong, in one or two sentences. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected vs. Actual
+
+<!-- What should happen vs. what actually happens. -->
+
+## Impact
+
+<!-- Who hits this and how often — blocks a core flow, edge case, cosmetic, etc. -->

--- a/templates/issue/coding-task.md
+++ b/templates/issue/coding-task.md
@@ -1,0 +1,22 @@
+---
+name: Coding Task
+about: Pure implementation work — a feature, refactor, or change with a code deliverable.
+title: ""
+labels: type:coding-task
+---
+
+## Value
+
+<!-- Why this matters — who benefits and what breaks or stalls without it. -->
+
+## Scope
+
+<!-- What's actually being built, which modules are affected. Note what's explicitly OUT of scope if
+     that's ambiguous. -->
+
+## Acceptance Criteria
+
+<!-- Concrete, checkable conditions — not "works well," but "X returns Y when Z." -->
+
+- [ ]
+- [ ]

--- a/templates/issue/config.yml
+++ b/templates/issue/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/templates/issue/epic.md
+++ b/templates/issue/epic.md
@@ -1,0 +1,20 @@
+---
+name: Epic
+about: A raw idea or theme that will break down into several tickets.
+title: ""
+labels: type:epic
+---
+
+## Idea
+
+<!-- What is this, roughly? The problem or opportunity, in a few sentences. -->
+
+## Why now
+
+<!-- What makes this worth doing — user pain, strategic bet, something blocking other work. -->
+
+## Shape
+
+<!-- Rough sense of what's involved — areas of the codebase touched, known unknowns.
+     Not a task breakdown; that happens as child issues get filed as native GitHub
+     sub-issues of this one. -->

--- a/templates/issue/spike.md
+++ b/templates/issue/spike.md
@@ -1,0 +1,35 @@
+---
+name: Spike / Decision
+about: A question that needs an answer, not code — e.g. choosing between architectures, tools, or platforms.
+title: "Spike: "
+labels: type:spike
+---
+
+## Value
+
+<!-- Why this decision matters now — what stays blocked or ambiguous without it. -->
+
+## Question to Answer
+
+<!-- The specific question this spike must answer. Not "figure out X" — a
+     question with a real yes/no or A/B/C shape. -->
+
+## Alternatives Considered
+
+<!-- Name at least two concrete options. A spike that only evaluates one
+     option isn't a decision, it's a confirmation. -->
+
+-
+-
+
+## Decision Criteria
+
+<!-- What makes one alternative win over another — cost, fit with existing
+     architecture, maintenance burden, etc. -->
+
+## Deliverable
+
+<!-- Where the decision gets recorded so dependent tickets can reference it.
+     If it's an ADR: include a comparison matrix (alternatives as columns,
+     Decision Criteria as rows, an explicit winner per row) — not prose in
+     table cells, and grounded in facts rather than "the requester wants X." -->


### PR DESCRIPTION
## What changed

- Imports the agent pipeline from `abi83/prepify` verbatim: reusable `workflow_call` cores (`issue-pipeline.yml`, `code-pipeline.yml`), composite actions, `pipeline/` + `gh-safe/` scripts and their `bats` tests, prompts, and `agent-pipeline.schema.json`.
- Cross-repo adaptation, since a reusable workflow's `./`-relative paths resolve against the *consumer* checkout, not this repo:
  - each reusable job resolves its own ref from `github.job_workflow_ref` and self-checks-out `abi83/interns` at that ref into `.interns/`
  - every asset path in the two workflows is rewritten to `.interns/…` (composite actions, script steps, prompt reads, the `ALLOWED_*` allowlists)
  - `resolve-agent-config` calls its script via `$GITHUB_ACTION_PATH` instead of a workspace-relative path
  - the wiki checkout is guarded on `vars.WIKI_REPO != ''`
- `lint-pipeline.yml`: actionlint + shellcheck + `bats`, plus a metaschema check.

Design: [abi83/prepify#152](https://github.com/abi83/prepify/issues/152#issuecomment-5478003073).

## Before merging

- Lint pipeline green (actionlint / shellcheck / 67 bats tests pass locally).
- The reusable cores can't execute here — they're `workflow_call`-only. End-to-end verification happens on the `abi83/prepify` caller-cutover PR after `v0.1.0` is tagged.

## After merging

- Tag `v0.1.0` on `main`.
- `abi83/prepify` repoints its caller stubs to `abi83/interns/.github/workflows/*.yml@v0.1.0` and deletes the moved copies.
- Close [abi83/prepify#152](https://github.com/abi83/prepify/issues/152).
