### PR TITLE
fix: valid YAML for the resolve-agent-config run step

### DIFF
--- a/.github/actions/resolve-agent-config/action.yml
+++ b/.github/actions/resolve-agent-config/action.yml
@@ -49,6 +49,6 @@ runs:
         PIPELINE_TIMEOUT_MINUTES: ${{ inputs.pipeline_timeout_minutes }}
         PIPELINE_MAX_OUTPUT_TOKENS: ${{ inputs.pipeline_max_output_tokens }}
         PIPELINE_COST_WARN_USD: ${{ inputs.pipeline_cost_warn_usd }}
-      # $GITHUB_ACTION_PATH is this action's dir; composite `run:` steps
+      # github.action_path is this action's dir; composite `run:` steps
       # otherwise default their cwd to the caller's workspace root.
-      run: "$GITHUB_ACTION_PATH/../../scripts/pipeline/agent-config.sh" ${{ inputs.agent }}
+      run: ${{ github.action_path }}/../../scripts/pipeline/agent-config.sh ${{ inputs.agent }}


### PR DESCRIPTION
`run: "$GITHUB_ACTION_PATH/..." ${{ inputs.agent }}` is a quoted scalar followed by junk — the action-manifest parser rejects it ("did not find expected key", Line 54). Caught by the first real cross-repo pipeline run on abi83/prepify#162: self-checkout, cross-repo composite actions, and the wiki checkout all worked; this step was the only failure.

Fix: plain `${{ github.action_path }}/../../scripts/pipeline/agent-config.sh ${{ inputs.agent }}` scalar.

## Before merging
- lint green

## After merging
- re-cut `v0.1.0` (nothing consumes it yet — abi83/prepify#162 is still open)