### PR TITLE
fix: reviewer diff source (#13) + coder fix-round give-up escalation (#9)

### DIFF
--- a/.github/prompts/code-fix.md
+++ b/.github/prompts/code-fix.md
@@ -24,8 +24,7 @@ number is supplied in your environment as `PR_NUMBER`).
 Don't modify CI or pipeline configuration — anything under
 `.github/workflows/`, or pipeline scripts the repo marks as protected.
 `push-branch.sh` rejects any push that touches those paths. If addressing
-the feedback requires such a change, stop and explain that on the PR
-(`comment-pr.sh`) instead.
+the feedback requires such a change, decline the task (see below).
 
 Re-check the repo's own conventions (`CLAUDE.md` / `AGENTS.md`, any
 contributor guide, or the existing code) if you need a refresher. Re-run
@@ -33,6 +32,27 @@ the project's build and test commands before pushing and keep them green —
 the same bar applies to a fix commit as to the original implementation, and
 a red check sends the issue to a human rather than back to you for another
 round.
+
+## If you can't complete the fix
+
+Some fix rounds can't be carried out: the feedback needs a change under
+`.github/workflows/` or another protected path (`push-branch.sh` will
+reject the push), the reviewer's request is out of scope for the issue or
+contradicts it, or resolving it needs a decision only the owner can make.
+
+In that case, **don't** just leave a PR comment and stop — a bare comment
+looks identical to a finished fix, so the pipeline hands the PR back to the
+reviewer for a wasted round. Instead:
+
+1. Write the reason to `./.coder-gave-up.md`: what you were asked to do,
+   why you can't, and what decision or change you need from the owner. A
+   few sentences of Markdown — it's posted verbatim to the issue.
+2. Optionally also reply on the PR with `comment-pr.sh` if a threaded
+   reply adds context.
+3. Stop without committing or pushing.
+
+The workflow detects the sentinel, sets `status:needs-attention`, and
+escalates to the owner instead of re-running the reviewer.
 
 ## Commit and push
 

--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -1,10 +1,21 @@
 You are reviewing a PR opened by the coder agent (or, occasionally, a
 human).
 
-Input: the PR's diff, the number of the linked issue it implements, and
-this repo's conventions. You're only given the linked issue's *number* —
-run `gh issue view <number>` yourself to read its Value/Scope/Acceptance
-Criteria before judging anything against them. If that issue references
+Input: the PR number, the number of the linked issue it implements, and
+this repo's conventions.
+
+Get the diff yourself with `gh pr diff <number>` — that's your
+authoritative source. It's the API diff, so it includes paths that aren't
+in your local checkout: `claude-code-action` relocates untrusted PR-head
+files (anything under `.github/workflows/`) to `.claude-pr/`, so `git diff`
+against the working tree can't show those changes. When you need a file's
+full contents rather than just the hunks, read it from `.claude-pr/` if
+it's there, otherwise from its normal path. Use `gh pr view <number>` for
+the PR description and conversation.
+
+You're only given the linked issue's *number* — run `gh issue view
+<number>` yourself to read its Value/Scope/Acceptance Criteria before
+judging anything against them. If that issue references
 other tickets that matter for context — a parent epic, a sub-issue, a
 ticket it says it depends on or supersedes — run `gh issue view` on those
 too rather than reviewing off the one issue in isolation.

--- a/.github/scripts/pipeline/handle-giveup.sh
+++ b/.github/scripts/pipeline/handle-giveup.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Runs after a coder fix round. If the agent left a ./.coder-gave-up.md sentinel
+# it has *declined* the task — the feedback needs a protected path it can't
+# push, is out of scope for the issue, or needs an owner decision — rather than
+# pushing a fix. Escalate straight to a human instead of handing the PR back to
+# the reviewer for a wasted round (#9).
+#
+# The coder step still exits 0 in this case (it's reporting, not failing), so
+# without this check the workflow can't tell "gave up and commented" from
+# "finished the fix" and would re-run the reviewer.
+#
+# Emits gave_up=true|false on $GITHUB_OUTPUT so the workflow skips the reviewer
+# hand-off when the task was declined.
+#
+# Usage: handle-giveup.sh <issue> <pr-number-or-empty>
+
+set -euo pipefail
+# shellcheck source=.github/scripts/pipeline/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+issue="$1"
+pr="${2:-}"
+sentinel="${GITHUB_WORKSPACE:-.}/.coder-gave-up.md"
+out="${GITHUB_OUTPUT:-/dev/null}"
+
+if [[ ! -f "$sentinel" ]]; then
+  echo "gave_up=false" >>"$out"
+  exit 0
+fi
+
+reason="$(cat "$sentinel")"
+[[ -n "${reason//[[:space:]]/}" ]] || reason="_(no reason given)_"
+
+if [[ -n "$pr" ]]; then
+  set_pr_pipeline_label "$pr"
+fi
+set_issue_status "$issue" status:needs-attention
+
+gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body \
+"The coder fix round declined this task and set \`status:needs-attention\` — it was not handed back to the reviewer.
+
+$reason
+
+Run: $(run_url)"
+
+echo "gave_up=true" >>"$out"

--- a/.github/scripts/pipeline/tests/handle-giveup.bats
+++ b/.github/scripts/pipeline/tests/handle-giveup.bats
@@ -1,0 +1,40 @@
+setup() {
+  load helpers
+  setup_stubs
+  export GITHUB_WORKSPACE="$BATS_TEST_TMPDIR/ws"
+  mkdir -p "$GITHUB_WORKSPACE"
+}
+
+@test "no sentinel: emits gave_up=false and does nothing" {
+  run "$PIPELINE_DIR/handle-giveup.sh" 7 15
+  [ "$status" -eq 0 ]
+  grep -q '^gave_up=false$' "$GITHUB_OUTPUT"
+  ! grep -q 'gh issue comment' "$STUB_LOG"
+  ! grep -q 'gh issue edit' "$STUB_LOG"
+}
+
+@test "sentinel present: escalates the issue, clears the PR label, comments the reason" {
+  export STUB_ISSUE_LABELS="status:in-progress"
+  export STUB_PR_LABELS="pr:coding"
+  printf 'Feedback needs a change under .github/workflows/ which I cannot push.\n' \
+    >"$GITHUB_WORKSPACE/.coder-gave-up.md"
+
+  run "$PIPELINE_DIR/handle-giveup.sh" 7 15
+  [ "$status" -eq 0 ]
+  grep -q '^gave_up=true$' "$GITHUB_OUTPUT"
+  grep -q 'gh issue edit 7 --repo owner/repo --add-label status:needs-attention --remove-label status:in-progress' "$STUB_LOG"
+  grep -q 'gh pr edit 15 --repo owner/repo --remove-label pr:coding' "$STUB_LOG"
+  grep -q 'gh issue comment 7 .* declined this task' "$STUB_LOG"
+  grep -q 'cannot push' "$STUB_LOG"
+}
+
+@test "sentinel present but empty: still escalates, with a placeholder reason" {
+  export STUB_ISSUE_LABELS="status:in-progress"
+  : >"$GITHUB_WORKSPACE/.coder-gave-up.md"
+
+  run "$PIPELINE_DIR/handle-giveup.sh" 7 ""
+  [ "$status" -eq 0 ]
+  grep -q '^gave_up=true$' "$GITHUB_OUTPUT"
+  grep -q 'no reason given' "$STUB_LOG"
+  ! grep -q 'gh pr edit' "$STUB_LOG"
+}

--- a/.github/workflows/code-pipeline.yml
+++ b/.github/workflows/code-pipeline.yml
@@ -55,6 +55,10 @@ env:
   ALLOWED_BUILD_TEST: "Bash(npm install:*),Bash(npm ci:*),Bash(npm test:*),Bash(npm run build:*)"
   ALLOWED_CI_READ: "Bash(gh pr checks:*),Bash(gh run view:*)"
   ALLOWED_ISSUE_READ: "Bash(gh issue view:*)"
+  # The reviewer's sanctioned diff source. `gh pr diff` returns the API diff,
+  # which includes paths (e.g. .github/workflows/**) that claude-code-action
+  # relocates out of the working tree, so `git diff` alone can't see them (#13).
+  ALLOWED_PR_READ: "Bash(gh pr diff:*),Bash(gh pr view:*)"
 
 jobs:
   coder:
@@ -264,15 +268,30 @@ jobs:
           "${{ steps.claude_initial.outputs.execution_file }}${{ steps.claude_fix.outputs.execution_file }}"
           "${{ steps.issue.outputs.number }}"
 
+      # A fix round that can't do the work (protected path, out-of-scope or
+      # contradictory feedback, needs an owner decision) leaves a
+      # ./.coder-gave-up.md sentinel instead of pushing. Escalate straight to a
+      # human rather than handing the PR back to the reviewer for a wasted
+      # round (#9). Exit 0 is kept — the agent isn't failing, it's reporting it
+      # can't proceed — so this is distinct from `Flag failure`.
+      - name: Check for coder give-up (fix round)
+        id: giveup
+        if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.fix_round == 'true' && success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          .interns/.github/scripts/pipeline/handle-giveup.sh
+          "${{ steps.issue.outputs.number }}" "${{ steps.pr.outputs.pr_number }}"
+
       - name: Check PR now exists
         id: verify_pr
-        if: steps.guard.outputs.skip != 'true' && success()
+        if: steps.guard.outputs.skip != 'true' && success() && steps.giveup.outputs.gave_up != 'true'
         uses: ./.interns/.github/actions/find-pr-for-issue
         with:
           issue_number: ${{ steps.issue.outputs.number }}
 
       - name: Hand off to reviewer
-        if: steps.guard.outputs.skip != 'true' && success()
+        if: steps.guard.outputs.skip != 'true' && success() && steps.giveup.outputs.gave_up != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: >
@@ -462,7 +481,7 @@ jobs:
           claude_args: |
             --model ${{ steps.cfg.outputs.model }}
             --max-turns ${{ steps.cfg.outputs.max_turns }}
-            --allowedTools "Read,Grep,Glob,Write,${{ env.ALLOWED_GIT_READ }},${{ env.ALLOWED_CI_READ }},${{ env.ALLOWED_ISSUE_READ }},${{ env.ALLOWED_SUBMIT_REVIEW }},${{ env.ALLOWED_COMMENT_PR }}"
+            --allowedTools "Read,Grep,Glob,Write,${{ env.ALLOWED_GIT_READ }},${{ env.ALLOWED_PR_READ }},${{ env.ALLOWED_CI_READ }},${{ env.ALLOWED_ISSUE_READ }},${{ env.ALLOWED_SUBMIT_REVIEW }},${{ env.ALLOWED_COMMENT_PR }}"
 
       - name: Report run cost
         if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && always() && steps.claude.outputs.execution_file != ''


### PR DESCRIPTION
Fixes #13 and #9 — two related pipeline-flow correctness bugs, one on each side of the coder↔reviewer loop.

## #13 — reviewer can't fetch a PR diff, submits no verdict

The reviewer's tool allowlist had `git diff` but no `gh pr diff` / `gh pr view`. `review.md` tells the agent its input is "the PR's diff", so it tries to fetch one, gets denied on every attempt, and ends without submitting a review — the no-verdict fallback then flags the issue `status:needs-attention` with a misleading "stopped partway through". Worse, `claude-code-action` relocates untrusted PR-head paths (`.github/workflows/**`) to `.claude-pr/`, so `git diff` can't show those changes even when allowed.

- New `ALLOWED_PR_READ` env (`gh pr diff:*`, `gh pr view:*`), added to the reviewer's `--allowedTools`.
- `review.md` "Input" section rewritten: get the diff with `gh pr diff <number>` (the API diff, which includes relocated paths), read full file contents from `.claude-pr/` when needed, use `gh pr view` for the description/conversation.

## #9 — coder fix round that declines the task loops back to the reviewer

A fix round that can't do the work (change needed under a protected path, out-of-scope/contradictory feedback, needs an owner decision) posted a PR comment and exited 0 — identical, to the workflow, to a finished fix. So the PR flipped back to `pr:in-review`, the reviewer ran a full pass again, re-requested the same change, and only the 2nd `CHANGES_REQUESTED` round cap escalated. One wasted reviewer run + a confusing label bounce every time.

- `code-fix.md` gains an explicit **"If you can't complete the fix"** path: write the reason to `./.coder-gave-up.md` and stop, instead of just commenting.
- New `.github/scripts/pipeline/handle-giveup.sh` runs after the fix step: if the sentinel exists, set `status:needs-attention`, clear the `pr:*` label, post the reason to the issue, and emit `gave_up=true`.
- `code-pipeline.yml` gates "Check PR now exists" and "Hand off to reviewer" on `steps.giveup.outputs.gave_up != 'true'`. Exit-0 semantics kept — declining is reporting, not failing, so this stays distinct from `Flag failure`.

## Tests

- `tests/handle-giveup.bats` — no sentinel → `gave_up=false`, no-op; sentinel present → escalates + clears PR label + comments reason; empty sentinel → still escalates with a placeholder.
- Full suite (70 pre-existing + 3 new) green; `shellcheck -x` and `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
