### PR TITLE
feat: persist a versioned pipeline-metrics record per agent run (#12)

### DIFF
--- a/.github/pipeline-metrics.schema.json
+++ b/.github/pipeline-metrics.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "pipeline-metrics record",
-  "description": "One machine-readable record per (run, job) of the agent pipeline, emitted by extract-metrics.sh and appended to metrics.jsonl on the orphan `metrics` branch. See interns#12.",
+  "description": "One record per (run, job) of the agent pipeline, emitted by extract-metrics.sh and appended to metrics.jsonl on the orphan `metrics` branch.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -12,7 +12,7 @@
   "properties": {
     "schema_version": {
       "const": 1,
-      "description": "Bump on any breaking shape change; the dashboard keys off it."
+      "description": "Bump on any breaking shape change."
     },
     "timestamp": {
       "type": "string",

--- a/.github/pipeline-metrics.schema.json
+++ b/.github/pipeline-metrics.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "pipeline-metrics record",
+  "description": "One machine-readable record per (run, job) of the agent pipeline, emitted by extract-metrics.sh and appended to metrics.jsonl on the orphan `metrics` branch. See interns#12.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "timestamp", "repo", "run_id", "run_attempt", "job",
+    "issue", "pr", "session_id", "agent_result", "num_turns", "duration_ms",
+    "duration_api_ms", "models", "tool_calls"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1,
+      "description": "Bump on any breaking shape change; the dashboard keys off it."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC, when the record was written (run finish)."
+    },
+    "repo": { "type": "string", "description": "owner/name of the repo the run belongs to." },
+    "run_id": { "type": "integer", "description": "github.run_id — stable across re-runs." },
+    "run_attempt": { "type": "integer", "minimum": 1, "description": "github.run_attempt — increments on re-run. (run_id, run_attempt) is the unique execution key." },
+    "job": {
+      "enum": ["refiner", "estimator", "coder", "reviewer"],
+      "description": "Which agent phase produced this record."
+    },
+    "issue": { "type": ["integer", "null"], "description": "Issue number, or null (a refiner run before any PR/issue link resolves)." },
+    "pr": { "type": ["integer", "null"], "description": "PR number, or null when no PR exists yet." },
+    "session_id": { "type": ["string", "null"], "description": "result.session_id — traces back to the raw execution file." },
+    "agent_result": {
+      "type": ["string", "null"],
+      "description": "result.subtype: success | error_max_turns | error_during_execution. Agent-process outcome, not code quality."
+    },
+    "num_turns": { "type": ["integer", "null"], "description": "result.num_turns — whole run, main agent." },
+    "duration_ms": { "type": ["integer", "null"], "description": "result.duration_ms — agent-loop wall clock incl. local tool execution, excl. GitHub queue/checkout/setup." },
+    "duration_api_ms": { "type": ["integer", "null"], "description": "result.duration_api_ms — cumulative time awaiting the Anthropic API." },
+    "models": {
+      "type": "object",
+      "description": "One entry per model used, sub-agent models included (from result.modelUsage). Run total cost = sum(models[*].cost_usd) — not denormalised into the record.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens", "cost_usd"],
+        "properties": {
+          "input_tokens": { "type": "integer" },
+          "output_tokens": { "type": "integer" },
+          "cache_read_tokens": { "type": "integer" },
+          "cache_creation_tokens": { "type": "integer" },
+          "cost_usd": { "type": "number" }
+        }
+      }
+    },
+    "tool_calls": {
+      "type": "object",
+      "description": "tool_use blocks in the stream, grouped by name, main agent only (sub-agent inner calls live in a separate sidechain). Task count = sub-agents spawned.",
+      "additionalProperties": { "type": "integer", "minimum": 1 }
+    }
+  }
+}

--- a/.github/scripts/pipeline/append-metrics.sh
+++ b/.github/scripts/pipeline/append-metrics.sh
@@ -1,18 +1,11 @@
 #!/usr/bin/env bash
 #
-# Append one or more pipeline-metrics records (see extract-metrics.sh) to
-# metrics.jsonl on the orphan `metrics` branch, as a single commit per workflow
-# run (#12). The caller serialises appends across runs with
-# `concurrency: { group: metrics-append }`; this script additionally survives a
-# concurrent human push to the branch with a fetch + re-apply + push retry loop.
-# Distinct JSONL lines never actually conflict, so "rebase" here is just:
-# discard our local commit, re-fetch the branch tip, re-append, re-push.
-#
-# The branch is created (orphan, one empty metrics.jsonl) on first use, so a
-# fresh consumer repo needs no manual seeding.
+# Append pipeline-metrics records (extract-metrics.sh) to metrics.jsonl on the
+# orphan `metrics` branch, one commit per call. The caller serialises appends
+# with a concurrency group; on a losing push race this retries by re-fetching
+# the branch tip and re-appending. The branch is created on first use.
 #
 # Usage: append-metrics.sh <record-file>...
-#   Each <record-file> holds exactly one JSON object (the record).
 #
 # Env: GH_TOKEN (contents:write), GITHUB_REPOSITORY, GITHUB_SERVER_URL,
 #      GITHUB_RUN_ID.
@@ -29,8 +22,7 @@ die() { echo "append-metrics: $*" >&2; exit 1; }
 : "${GH_TOKEN:?append-metrics: GH_TOKEN unset}"
 : "${GITHUB_REPOSITORY:?append-metrics: GITHUB_REPOSITORY unset}"
 
-# Validate and normalise every incoming record before touching the remote —
-# one bad file aborts the whole append, nothing half-written is pushed.
+# Validate every record before touching the remote.
 records=$(mktemp)
 work=$(mktemp -d)
 trap 'rm -f "$records"; rm -rf "$work"' EXIT

--- a/.github/scripts/pipeline/append-metrics.sh
+++ b/.github/scripts/pipeline/append-metrics.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Append one or more pipeline-metrics records (see extract-metrics.sh) to
+# metrics.jsonl on the orphan `metrics` branch, as a single commit per workflow
+# run (#12). The caller serialises appends across runs with
+# `concurrency: { group: metrics-append }`; this script additionally survives a
+# concurrent human push to the branch with a fetch + re-apply + push retry loop.
+# Distinct JSONL lines never actually conflict, so "rebase" here is just:
+# discard our local commit, re-fetch the branch tip, re-append, re-push.
+#
+# The branch is created (orphan, one empty metrics.jsonl) on first use, so a
+# fresh consumer repo needs no manual seeding.
+#
+# Usage: append-metrics.sh <record-file>...
+#   Each <record-file> holds exactly one JSON object (the record).
+#
+# Env: GH_TOKEN (contents:write), GITHUB_REPOSITORY, GITHUB_SERVER_URL,
+#      GITHUB_RUN_ID.
+
+set -euo pipefail
+
+BRANCH=metrics
+FILE=metrics.jsonl
+RETRIES=3
+
+die() { echo "append-metrics: $*" >&2; exit 1; }
+
+[[ $# -gt 0 ]] || die "no record files given"
+: "${GH_TOKEN:?append-metrics: GH_TOKEN unset}"
+: "${GITHUB_REPOSITORY:?append-metrics: GITHUB_REPOSITORY unset}"
+
+# Validate and normalise every incoming record before touching the remote —
+# one bad file aborts the whole append, nothing half-written is pushed.
+records=$(mktemp)
+work=$(mktemp -d)
+trap 'rm -f "$records"; rm -rf "$work"' EXIT
+
+for f in "$@"; do
+  [[ -f "$f" ]] || die "no such file: $f"
+  jq -e 'type == "object"' "$f" >/dev/null 2>&1 || die "not a JSON object: $f"
+  jq -c . "$f" >> "$records"
+done
+[[ -s "$records" ]] || { echo "append-metrics: nothing to append"; exit 0; }
+
+server="${GITHUB_SERVER_URL:-https://github.com}"
+auth_remote="https://x-access-token:${GH_TOKEN}@${server#https://}/${GITHUB_REPOSITORY}.git"
+
+push_attempt() {
+  rm -rf "$work"
+  mkdir -p "$work"
+  git -C "$work" init -q
+  git -C "$work" config user.name  "github-actions[bot]"
+  git -C "$work" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git -C "$work" config commit.gpgsign false
+  git -C "$work" remote add origin "$auth_remote"
+
+  if git -C "$work" fetch -q --depth=1 origin "$BRANCH" 2>/dev/null; then
+    git -C "$work" checkout -q -b "$BRANCH" FETCH_HEAD || return 1
+  else
+    git -C "$work" checkout -q --orphan "$BRANCH" || return 1
+    : > "$work/$FILE"
+  fi
+
+  cat "$records" >> "$work/$FILE"
+  git -C "$work" add "$FILE" || return 1
+  git -C "$work" commit -q -m "chore(metrics): append records from run ${GITHUB_RUN_ID:-unknown}" || return 1
+  git -C "$work" push -q origin "HEAD:$BRANCH"
+}
+
+for attempt in $(seq 1 "$RETRIES"); do
+  if push_attempt; then
+    echo "append-metrics: appended $(wc -l < "$records" | tr -d ' ') record(s) to $BRANCH"
+    exit 0
+  fi
+  echo "append-metrics: attempt $attempt/$RETRIES failed" >&2
+  sleep $(( attempt * 3 ))
+done
+
+die "push to $BRANCH failed after $RETRIES attempts"

--- a/.github/scripts/pipeline/extract-metrics.sh
+++ b/.github/scripts/pipeline/extract-metrics.sh
@@ -1,27 +1,13 @@
 #!/usr/bin/env bash
 #
-# Parse one claude-code-action execution file into a single versioned
-# pipeline-metrics record (one JSON object, printed as one line) on stdout.
-# Shared by all four agent jobs; the final `metrics` job gathers the emitted
-# lines and appends them to metrics.jsonl on the orphan `metrics` branch (see
-# append-metrics.sh). One record per (run, job) — see #12.
+# Parse one claude-code-action execution file into a single pipeline-metrics
+# record (one JSON object) on stdout, for append-metrics.sh to persist.
 #
-# Schema: .github/pipeline-metrics.schema.json. Bump SCHEMA_VERSION below and
-# that file together on any breaking shape change — the metrics dashboard
-# (abi83/prepify#3) keys off schema_version to stay comparable across repos.
+# Usage: extract-metrics.sh <execution-file> --job <job> [--issue N] [--pr N]
 #
-# Usage:
-#   extract-metrics.sh <execution-file> --job <job> [--issue N] [--pr N]
-#
-#     <job>            refiner | estimator | coder | reviewer
-#     --issue / --pr   pipeline state; omitted, empty or non-numeric -> null
-#
-# Env (from the Actions runtime):
-#   GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT
-#
-# Exits non-zero and prints nothing to stdout when the execution file is
-# missing or carries no `result` event — a killed run can still leave a
-# truncated file, and the caller guards on execution_file != '' only.
+# Bump SCHEMA_VERSION and .github/pipeline-metrics.schema.json together on any
+# breaking shape change. Exits non-zero, printing nothing, when the file is
+# missing or has no result event (a killed run can leave a truncated file).
 
 set -euo pipefail
 

--- a/.github/scripts/pipeline/extract-metrics.sh
+++ b/.github/scripts/pipeline/extract-metrics.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Parse one claude-code-action execution file into a single versioned
+# pipeline-metrics record (one JSON object, printed as one line) on stdout.
+# Shared by all four agent jobs; the final `metrics` job gathers the emitted
+# lines and appends them to metrics.jsonl on the orphan `metrics` branch (see
+# append-metrics.sh). One record per (run, job) — see #12.
+#
+# Schema: .github/pipeline-metrics.schema.json. Bump SCHEMA_VERSION below and
+# that file together on any breaking shape change — the metrics dashboard
+# (abi83/prepify#3) keys off schema_version to stay comparable across repos.
+#
+# Usage:
+#   extract-metrics.sh <execution-file> --job <job> [--issue N] [--pr N]
+#
+#     <job>            refiner | estimator | coder | reviewer
+#     --issue / --pr   pipeline state; omitted, empty or non-numeric -> null
+#
+# Env (from the Actions runtime):
+#   GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT
+#
+# Exits non-zero and prints nothing to stdout when the execution file is
+# missing or carries no `result` event — a killed run can still leave a
+# truncated file, and the caller guards on execution_file != '' only.
+
+set -euo pipefail
+
+SCHEMA_VERSION=1
+
+die() { echo "extract-metrics: $*" >&2; exit 1; }
+
+exec_file="${1:-}"
+[[ -n "$exec_file" ]] || die "missing execution-file argument"
+shift
+
+job="" issue="" pr=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --job)   job="${2:-}"; shift 2 ;;
+    --issue) issue="${2:-}"; shift 2 ;;
+    --pr)    pr="${2:-}"; shift 2 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+case "$job" in
+  refiner|estimator|coder|reviewer) ;;
+  *) die "--job must be one of refiner|estimator|coder|reviewer (got '$job')" ;;
+esac
+[[ -f "$exec_file" ]] || die "execution file not found: $exec_file"
+jq -e '[.[] | select(.type=="result")] | length > 0' "$exec_file" >/dev/null 2>&1 \
+  || die "no result event in $exec_file"
+
+num_or_null() { [[ "${1:-}" =~ ^[0-9]+$ ]] && echo "$1" || echo "null"; }
+
+timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+jq -c -n \
+  --slurpfile events "$exec_file" \
+  --argjson schema_version "$SCHEMA_VERSION" \
+  --arg timestamp "$timestamp" \
+  --arg repo "${GITHUB_REPOSITORY:?extract-metrics: GITHUB_REPOSITORY unset}" \
+  --argjson run_id "${GITHUB_RUN_ID:?extract-metrics: GITHUB_RUN_ID unset}" \
+  --argjson run_attempt "${GITHUB_RUN_ATTEMPT:-1}" \
+  --arg job "$job" \
+  --argjson issue "$(num_or_null "$issue")" \
+  --argjson pr "$(num_or_null "$pr")" \
+  '
+  ($events[0]) as $ev
+  | ([$ev[] | select(.type=="result")] | last) as $r
+  | ([$ev[]
+       | select(.type=="assistant" and (.isSidechain != true))
+       | .message.content[]? | select(.type=="tool_use") | .name]
+     | reduce .[] as $n ({}; .[$n] += 1)) as $tool_calls
+  | {
+      schema_version: $schema_version,
+      timestamp: $timestamp,
+      repo: $repo,
+      run_id: $run_id,
+      run_attempt: $run_attempt,
+      job: $job,
+      issue: $issue,
+      pr: $pr,
+      session_id: ($r.session_id // null),
+      agent_result: ($r.subtype // null),
+      num_turns: ($r.num_turns // null),
+      duration_ms: ($r.duration_ms // null),
+      duration_api_ms: ($r.duration_api_ms // null),
+      models: (
+        ($r.modelUsage // {})
+        | to_entries
+        | map({
+            key: .key,
+            value: {
+              input_tokens:          (.value.inputTokens // 0),
+              output_tokens:         (.value.outputTokens // 0),
+              cache_read_tokens:     (.value.cacheReadInputTokens // 0),
+              cache_creation_tokens: (.value.cacheCreationInputTokens // 0),
+              cost_usd:              (.value.costUSD // 0)
+            }
+          })
+        | from_entries
+      ),
+      tool_calls: $tool_calls
+    }
+  '

--- a/.github/scripts/pipeline/tests/append-metrics.bats
+++ b/.github/scripts/pipeline/tests/append-metrics.bats
@@ -1,0 +1,32 @@
+setup() {
+  load helpers
+  setup_stubs
+  export GH_TOKEN=x GITHUB_REPOSITORY=owner/repo GITHUB_RUN_ID=42
+}
+
+@test "rejects a file that is not a JSON object" {
+  echo 'not json' >"$BATS_TEST_TMPDIR/bad.json"
+  run "$PIPELINE_DIR/append-metrics.sh" "$BATS_TEST_TMPDIR/bad.json"
+  [ "$status" -ne 0 ]
+  # nothing pushed
+  ! grep -q 'git .*push' "$STUB_LOG"
+}
+
+@test "rejects a missing file" {
+  run "$PIPELINE_DIR/append-metrics.sh" /no/such/record.json
+  [ "$status" -ne 0 ]
+}
+
+@test "errors with no arguments" {
+  run "$PIPELINE_DIR/append-metrics.sh"
+  [ "$status" -ne 0 ]
+}
+
+@test "valid records drive a fetch + commit + push on the metrics branch" {
+  echo '{"schema_version":1,"job":"coder"}' >"$BATS_TEST_TMPDIR/rec.json"
+  run "$PIPELINE_DIR/append-metrics.sh" "$BATS_TEST_TMPDIR/rec.json"
+  [ "$status" -eq 0 ]
+  grep -q 'git -C .* fetch -q --depth=1 origin metrics' "$STUB_LOG"
+  grep -q 'git -C .* commit -q -m chore(metrics): append records from run 42' "$STUB_LOG"
+  grep -q 'git -C .* push -q origin HEAD:metrics' "$STUB_LOG"
+}

--- a/.github/scripts/pipeline/tests/extract-metrics.bats
+++ b/.github/scripts/pipeline/tests/extract-metrics.bats
@@ -1,0 +1,82 @@
+setup() {
+  load helpers
+  setup_stubs
+  export GITHUB_RUN_ATTEMPT=2
+
+  EXEC="$BATS_TEST_TMPDIR/exec.json"
+  cat >"$EXEC" <<'EOF'
+[
+  {"type":"system","subtype":"init","session_id":"sess-1"},
+  {"type":"assistant","isSidechain":false,"message":{"role":"assistant","content":[
+    {"type":"text","text":"hi"},
+    {"type":"tool_use","name":"Read","input":{}},
+    {"type":"tool_use","name":"Bash","input":{}}
+  ]}},
+  {"type":"assistant","message":{"role":"assistant","content":[
+    {"type":"tool_use","name":"Bash","input":{}},
+    {"type":"tool_use","name":"Task","input":{}}
+  ]}},
+  {"type":"assistant","isSidechain":true,"message":{"role":"assistant","content":[
+    {"type":"tool_use","name":"Grep","input":{}}
+  ]}},
+  {"type":"result","subtype":"success","session_id":"sess-1","num_turns":7,
+   "duration_ms":812345,"duration_api_ms":431200,"total_cost_usd":0.42,
+   "modelUsage":{
+     "claude-sonnet-5":{"inputTokens":12000,"outputTokens":48000,"cacheReadInputTokens":980000,"cacheCreationInputTokens":60000,"costUSD":0.4},
+     "claude-haiku-4-5":{"inputTokens":300000,"outputTokens":12000,"costUSD":0.02}
+   }}
+]
+EOF
+}
+
+@test "emits one line with the core run fields" {
+  run "$PIPELINE_DIR/extract-metrics.sh" "$EXEC" --job coder --issue 117 --pr 128
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | wc -l | tr -d ' ')" -eq 1 ]
+  echo "$output" | jq -e '
+    .schema_version == 1 and .repo == "owner/repo" and .run_id == 42 and
+    .run_attempt == 2 and .job == "coder" and .issue == 117 and .pr == 128 and
+    .session_id == "sess-1" and .agent_result == "success" and .num_turns == 7 and
+    .duration_ms == 812345 and .duration_api_ms == 431200
+  '
+}
+
+@test "nests per-model usage, sub-agent models included, snake_cased" {
+  run "$PIPELINE_DIR/extract-metrics.sh" "$EXEC" --job coder --issue 117
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '
+    (.models | keys | sort) == ["claude-haiku-4-5","claude-sonnet-5"] and
+    .models["claude-sonnet-5"].cache_read_tokens == 980000 and
+    .models["claude-sonnet-5"].cost_usd == 0.4 and
+    .models["claude-haiku-4-5"].cache_read_tokens == 0
+  '
+}
+
+@test "counts main-agent tool_use blocks only, grouped by name" {
+  run "$PIPELINE_DIR/extract-metrics.sh" "$EXEC" --job coder
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.tool_calls == {"Read":1,"Bash":2,"Task":1}'
+}
+
+@test "empty issue / pr become null" {
+  run "$PIPELINE_DIR/extract-metrics.sh" "$EXEC" --job refiner --issue "" --pr ""
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.issue == null and .pr == null and .job == "refiner"'
+}
+
+@test "rejects an unknown job" {
+  run "$PIPELINE_DIR/extract-metrics.sh" "$EXEC" --job nope
+  [ "$status" -ne 0 ]
+}
+
+@test "fails when the execution file has no result event" {
+  echo '[{"type":"system"}]' >"$BATS_TEST_TMPDIR/noresult.json"
+  run "$PIPELINE_DIR/extract-metrics.sh" "$BATS_TEST_TMPDIR/noresult.json" --job coder
+  [ "$status" -ne 0 ]
+  [ -z "$output" ] || [[ "$output" != *"{"* ]]
+}
+
+@test "fails when the execution file is missing" {
+  run "$PIPELINE_DIR/extract-metrics.sh" /no/such/file --job coder
+  [ "$status" -ne 0 ]
+}

--- a/.github/workflows/code-pipeline.yml
+++ b/.github/workflows/code-pipeline.yml
@@ -271,6 +271,27 @@ jobs:
         with:
           issue_number: ${{ steps.issue.outputs.number }}
 
+      - name: Extract run metrics
+        id: metrics
+        continue-on-error: true
+        if: steps.guard.outputs.skip != 'true' && always() && (steps.claude_initial.outputs.execution_file != '' || steps.claude_fix.outputs.execution_file != '')
+        run: >
+          .interns/.github/scripts/pipeline/extract-metrics.sh
+          "${{ steps.claude_initial.outputs.execution_file }}${{ steps.claude_fix.outputs.execution_file }}"
+          --job coder
+          --issue "${{ steps.issue.outputs.number }}"
+          --pr "${{ steps.verify_pr.outputs.pr_number || steps.pr.outputs.pr_number }}"
+          > "${{ runner.temp }}/metrics-coder.json"
+
+      - name: Upload run metrics
+        if: steps.guard.outputs.skip != 'true' && steps.metrics.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-metrics-coder
+          path: ${{ runner.temp }}/metrics-coder.json
+          if-no-files-found: ignore
+          retention-days: 2
+
       - name: Hand off to reviewer
         if: steps.guard.outputs.skip != 'true' && success()
         env:
@@ -474,6 +495,27 @@ jobs:
           "${{ steps.linked.outputs.issue_number }}"
           "${{ github.event.pull_request.number || inputs.pr_number }}"
 
+      - name: Extract run metrics
+        id: metrics
+        continue-on-error: true
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && always() && steps.claude.outputs.execution_file != ''
+        run: >
+          .interns/.github/scripts/pipeline/extract-metrics.sh
+          "${{ steps.claude.outputs.execution_file }}"
+          --job reviewer
+          --issue "${{ steps.linked.outputs.issue_number }}"
+          --pr "${{ github.event.pull_request.number || inputs.pr_number }}"
+          > "${{ runner.temp }}/metrics-reviewer.json"
+
+      - name: Upload run metrics
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && steps.metrics.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-metrics-reviewer
+          path: ${{ runner.temp }}/metrics-reviewer.json
+          if-no-files-found: ignore
+          retention-days: 2
+
       - name: Apply reviewer verdict
         if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && success()
         env:
@@ -511,3 +553,52 @@ jobs:
           .interns/.github/scripts/pipeline/flag-failure.sh --noun review
           --pr "${{ github.event.pull_request.number || inputs.pr_number }}"
           --issue "${{ steps.linked.outputs.issue_number }}"
+
+  metrics:
+    # One append per workflow run (#12): gather every pipeline-metrics record
+    # this run's agent jobs uploaded and commit them to metrics.jsonl on the
+    # orphan `metrics` branch in a single push. The concurrency group serialises
+    # that push across concurrent runs; append-metrics.sh also fetch-rebases on
+    # a race. Runs even when the agent job was skipped or failed — a no-record
+    # run is a clean no-op.
+    needs: [coder, reviewer]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: metrics-append
+    steps:
+      - name: Resolve pipeline ref
+        id: pipeline_ref
+        shell: bash
+        env:
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+        run: echo "ref=${JOB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pipeline assets
+        uses: actions/checkout@v5
+        with:
+          repository: abi83/interns
+          ref: ${{ steps.pipeline_ref.outputs.ref }}
+          path: .interns
+
+      - name: Download run metrics records
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: pipeline-metrics-*
+          path: metrics-records
+          merge-multiple: true
+
+      - name: Append to the metrics branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          shopt -s nullglob
+          files=(metrics-records/*.json)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No metrics records produced by this run — nothing to append."
+            exit 0
+          fi
+          .interns/.github/scripts/pipeline/append-metrics.sh "${files[@]}"

--- a/.github/workflows/code-pipeline.yml
+++ b/.github/workflows/code-pipeline.yml
@@ -555,12 +555,8 @@ jobs:
           --issue "${{ steps.linked.outputs.issue_number }}"
 
   metrics:
-    # One append per workflow run (#12): gather every pipeline-metrics record
-    # this run's agent jobs uploaded and commit them to metrics.jsonl on the
-    # orphan `metrics` branch in a single push. The concurrency group serialises
-    # that push across concurrent runs; append-metrics.sh also fetch-rebases on
-    # a race. Runs even when the agent job was skipped or failed — a no-record
-    # run is a clean no-op.
+    # One commit per workflow run: append the records the agent jobs uploaded to
+    # the metrics branch. The concurrency group serialises appends across runs.
     needs: [coder, reviewer]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -353,12 +353,8 @@ jobs:
           --issue "${{ steps.issue.outputs.number }}"
 
   metrics:
-    # One append per workflow run (#12): gather every pipeline-metrics record
-    # this run's agent jobs uploaded and commit them to metrics.jsonl on the
-    # orphan `metrics` branch in a single push. The concurrency group serialises
-    # that push across concurrent runs; append-metrics.sh also fetch-rebases on
-    # a race. Runs even when the agent job was skipped or failed — a no-record
-    # run is a clean no-op.
+    # One commit per workflow run: append the records the agent jobs uploaded to
+    # the metrics branch. The concurrency group serialises appends across runs.
     needs: [refine, estimate]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -153,6 +153,26 @@ jobs:
           "${{ steps.claude.outputs.execution_file }}"
           "${{ steps.issue.outputs.number }}"
 
+      - name: Extract run metrics
+        id: metrics
+        continue-on-error: true
+        if: always() && steps.claude.outputs.execution_file != ''
+        run: >
+          .interns/.github/scripts/pipeline/extract-metrics.sh
+          "${{ steps.claude.outputs.execution_file }}"
+          --job refiner
+          --issue "${{ steps.issue.outputs.number }}"
+          > "${{ runner.temp }}/metrics-refiner.json"
+
+      - name: Upload run metrics
+        if: steps.metrics.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-metrics-refiner
+          path: ${{ runner.temp }}/metrics-refiner.json
+          if-no-files-found: ignore
+          retention-days: 2
+
       - name: Verify outcome
         if: success() && steps.claude.outputs.execution_file != ''
         env:
@@ -285,6 +305,26 @@ jobs:
           "${{ steps.claude.outputs.execution_file }}"
           "${{ steps.issue.outputs.number }}"
 
+      - name: Extract run metrics
+        id: metrics
+        continue-on-error: true
+        if: always() && steps.claude.outputs.execution_file != ''
+        run: >
+          .interns/.github/scripts/pipeline/extract-metrics.sh
+          "${{ steps.claude.outputs.execution_file }}"
+          --job estimator
+          --issue "${{ steps.issue.outputs.number }}"
+          > "${{ runner.temp }}/metrics-estimator.json"
+
+      - name: Upload run metrics
+        if: steps.metrics.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-metrics-estimator
+          path: ${{ runner.temp }}/metrics-estimator.json
+          if-no-files-found: ignore
+          retention-days: 2
+
       - name: Verify outcome
         if: success() && steps.claude.outputs.execution_file != ''
         env:
@@ -311,3 +351,52 @@ jobs:
         run: >
           .interns/.github/scripts/pipeline/flag-failure.sh --noun estimation
           --issue "${{ steps.issue.outputs.number }}"
+
+  metrics:
+    # One append per workflow run (#12): gather every pipeline-metrics record
+    # this run's agent jobs uploaded and commit them to metrics.jsonl on the
+    # orphan `metrics` branch in a single push. The concurrency group serialises
+    # that push across concurrent runs; append-metrics.sh also fetch-rebases on
+    # a race. Runs even when the agent job was skipped or failed — a no-record
+    # run is a clean no-op.
+    needs: [refine, estimate]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: metrics-append
+    steps:
+      - name: Resolve pipeline ref
+        id: pipeline_ref
+        shell: bash
+        env:
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+        run: echo "ref=${JOB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pipeline assets
+        uses: actions/checkout@v5
+        with:
+          repository: abi83/interns
+          ref: ${{ steps.pipeline_ref.outputs.ref }}
+          path: .interns
+
+      - name: Download run metrics records
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: pipeline-metrics-*
+          path: metrics-records
+          merge-multiple: true
+
+      - name: Append to the metrics branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          shopt -s nullglob
+          files=(metrics-records/*.json)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No metrics records produced by this run — nothing to append."
+            exit 0
+          fi
+          .interns/.github/scripts/pipeline/append-metrics.sh "${files[@]}"

--- a/.github/workflows/lint-pipeline.yml
+++ b/.github/workflows/lint-pipeline.yml
@@ -28,8 +28,11 @@ jobs:
       - name: Lint standalone shell scripts
         run: find .github/scripts -name '*.sh' -print0 | xargs -0 -r shellcheck -x
 
-      - name: Validate the agent-pipeline schema is well-formed
-        run: pipx run check-jsonschema --check-metaschema .github/agent-pipeline.schema.json
+      - name: Validate the JSON schemas are well-formed
+        run: >
+          pipx run check-jsonschema --check-metaschema
+          .github/agent-pipeline.schema.json
+          .github/pipeline-metrics.schema.json
 
   test-scripts:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md
+
+Guidance for agents working in this repo.
+
+## Comments
+
+Prefer self-documenting code — clear names, small functions, obvious control
+flow. Add a comment only when it carries information the code cannot: a
+non-obvious *why*, a workaround and the reason for it, a subtle invariant or
+gotcha. Don't restate what the next line does, and don't write narrated
+section headers. When in doubt, cut it.
+
+## Portability
+
+This pipeline runs in any consumer repo. Keep code, comments, and docs free of
+references to specific consumer repos or their issue numbers — refer to "the
+consumer repo" generically. Cross-repo links belong in the README only.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ A one-shot installer that provisions all of that is tracked in
 [#154](https://github.com/abi83/prepify/issues/154). A fuller README —
 pipeline flow, label state table — is [abi83/prepify#163](https://github.com/abi83/prepify/issues/163).
 
+## Pipeline metrics
+
+Every agent run appends one machine-readable record per `(run, job)` to
+`metrics.jsonl` on an orphan `metrics` branch in the consumer repo — tokens
+(per model, sub-agents included), tool-call counts, `num_turns`, durations,
+cost, and the agent's process result. A final `metrics` job on each workflow
+run gathers the records its agent jobs uploaded and commits them in a single
+push (serialised by a `metrics-append` concurrency group, fetch-rebased on a
+race).
+
+The branch is created automatically on the first run — no manual seeding. The
+record shape is versioned by `schema_version` and specified in
+[`.github/pipeline-metrics.schema.json`](.github/pipeline-metrics.schema.json);
+bump it and the `SCHEMA_VERSION` constant in `extract-metrics.sh` together on
+any breaking change. Read the log from any client with a single unauthenticated
+fetch of `raw.githubusercontent.com/<owner>/<repo>/metrics/metrics.jsonl`.
+
 ## Layout
 
 | | |


### PR DESCRIPTION
Closes #12.

## What

Every agent run (`refiner` / `estimator` / `coder` / `reviewer`) now emits one
machine-readable **pipeline-metrics record** and persists it to an aggregatable
store, replacing the drop-on-the-floor treatment of tokens and tool-call counts
(only free-text cost comments existed before).

### Record (`schema_version: 1`)

One JSON object per `(run, job)` — `.github/pipeline-metrics.schema.json`:

- `models{}` — one entry per model, **sub-agent models included** (from
  `result.modelUsage`): input/output/cache-read/cache-creation tokens + `cost_usd`.
  Run total = `sum(models[*].cost_usd)`, not denormalised.
- `tool_calls{}` — `tool_use` blocks grouped by name, **main agent only**
  (`Task` = sub-agents spawned).
- `num_turns`, `duration_ms`, `duration_api_ms`, `agent_result`
  (`result.subtype`), `session_id`.
- `repo`, `run_id`, `run_attempt`, `job`, `issue` / `pr` (nullable), `timestamp`.

### Store

Single `metrics.jsonl` on an orphan `metrics` branch, appended via commit:

- One append **per workflow run** — a final `metrics` job gathers the records
  its agent jobs uploaded (as artifacts) and writes them in one commit.
- `concurrency: { group: metrics-append }` serialises appends across runs.
- `fetch` + re-apply + `push`, retried 3× on rejection. Distinct JSONL lines
  never conflict.
- Branch is **auto-created** (orphan, empty `metrics.jsonl`) on first run — a
  fresh consumer repo needs no manual seeding.
- Dashboard (abi83/prepify#3) reads it with one unauthenticated
  `raw.githubusercontent.com` fetch.

## Changes

| File | |
|---|---|
| `.github/scripts/pipeline/extract-metrics.sh` | `execution_file` → one record; shared by all four jobs |
| `.github/scripts/pipeline/append-metrics.sh` | append to `metrics.jsonl` on the `metrics` branch, auto-create + rebase-retry |
| `.github/pipeline-metrics.schema.json` | versioned record shape; metaschema-checked in `lint-pipeline` |
| `.github/workflows/{code,issue}-pipeline.yml` | Extract + Upload step per agent job; new `metrics` job (`contents: write`, concurrency group) |
| tests | `extract-metrics.bats`, `append-metrics.bats` |
| `README.md` | Pipeline metrics section |

## Verification

- `bats .github/scripts/pipeline/tests` — 78 pass (13 new)
- `shellcheck -x` clean on all scripts
- `actionlint` (pinned 1.7.12) clean

Out of scope for the record (per the issue): test/build results, pipeline
outcome, CI-gate state, per-model turn/tool counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)