### PR TITLE
docs: fix stale installer/roadmap issue links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ over a checked-out repo, respects its `CLAUDE.md` / `AGENTS.md`, and runs
 entirely in the consumer repo's GitHub Actions — no hosted service.
 
 Status: early. Consumed by [`abi83/prepify`](https://github.com/abi83/prepify).
-Design and roadmap: [abi83/prepify#130](https://github.com/abi83/prepify/issues/130).
+Design and roadmap: [#3](https://github.com/abi83/interns/issues/3).
 
 ## Consuming it
 
@@ -35,13 +35,15 @@ jobs:
 
 Needs, in the consumer repo: `CLAUDE_CODE_OAUTH_TOKEN` +
 `REVIEWER_APP_PRIVATE_KEY` secrets, a `REVIEWER_APP_ID` var, the
-`status:*` / `type:*` / `size:*` labels, and default-branch protection.
+`status:*` / `type:*` / `size:*` / `priority:*` / `pr:*` labels, and
+default-branch protection.
 Optional: `.github/agent-pipeline.yml` (per-agent model + limits).
 
-A one-shot installer that provisions all of that is tracked in
-[abi83/prepify#153](https://github.com/abi83/prepify/issues/153) /
-[#154](https://github.com/abi83/prepify/issues/154). A fuller README —
-pipeline flow, label state table — is [abi83/prepify#163](https://github.com/abi83/prepify/issues/163).
+A one-shot installer that provisions all of that — a versioned label
+manifest plus prerequisite/safety checks — is tracked in
+[#4](https://github.com/abi83/interns/issues/4) /
+[#5](https://github.com/abi83/interns/issues/5). A fuller README —
+pipeline flow, label state table — is [#10](https://github.com/abi83/interns/issues/10).
 
 ## Layout
 


### PR DESCRIPTION
## What

The README pointed at prepify issues that no longer exist as such:

| README said | Reality |
|---|---|
| `prepify#130` (design & roadmap) | tracking epic is now **#3** |
| `prepify#153` / `#154` (installer) | moved here as **#4** (label manifest + installer) / **#5** (safety checks) |
| `prepify#163` (fuller README) | moved here as **#10** |

Also lists `priority:*` and `pr:*` in the consumer label prerequisites — the pipeline scripts reference `pr:coding` / `pr:in-review` (and soon `pr:needs-attention`, #20) but the README only mentioned `status:*` / `type:*` / `size:*`.

## Context

Fallout from the #16 dependency review: #16 depended on `prepify#147`, which was pipeline work misfiled in prepify. That issue is now **#20** here (re-parented under #3), label creation delegated to the manifest in **#4**, and #16's depends-on updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)