### PR TITLE
feat: versioned label manifest + idempotent installer workflow

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "./labels.schema.json",
+  "version": 1,
+  "labels": [
+    { "name": "status:needs-refinement", "color": "1d76db", "description": "Issue pipeline: awaiting the refiner agent" },
+    { "name": "status:refined", "color": "1d76db", "description": "Issue pipeline: refined, awaiting estimation" },
+    { "name": "status:estimated", "color": "1d76db", "description": "Issue pipeline: estimated, awaiting owner approval" },
+    { "name": "status:estimated-wrong", "color": "d93f0b", "description": "Issue pipeline: estimate rejected by the owner" },
+    { "name": "status:ready", "color": "0e8a16", "description": "Approved for the coder agent to implement" },
+    { "name": "status:in-progress", "color": "fbca04", "description": "A coder agent run is working this issue" },
+    { "name": "status:needs-attention", "color": "b60205", "description": "Pipeline stalled — a human needs to look" },
+
+    { "name": "type:bug", "color": "5319e7", "description": "A defect in existing behaviour" },
+    { "name": "type:coding-task", "color": "5319e7", "description": "An implementable code deliverable" },
+    { "name": "type:epic", "color": "5319e7", "description": "A tracking issue with child sub-issues" },
+    { "name": "type:spike", "color": "5319e7", "description": "Time-boxed investigation, no shipped code required" },
+
+    { "name": "size:XS", "color": "c5def5", "description": "Estimate: extra small" },
+    { "name": "size:S", "color": "c5def5", "description": "Estimate: small" },
+    { "name": "size:M", "color": "c5def5", "description": "Estimate: medium" },
+    { "name": "size:L", "color": "c5def5", "description": "Estimate: large" },
+    { "name": "size:XL", "color": "c5def5", "description": "Estimate: extra large — consider splitting" },
+
+    { "name": "priority:low", "color": "d4c5f9", "description": "Priority: low" },
+    { "name": "priority:medium", "color": "d4c5f9", "description": "Priority: medium" },
+    { "name": "priority:high", "color": "d4c5f9", "description": "Priority: high" },
+    { "name": "priority:urgent", "color": "d4c5f9", "description": "Priority: urgent" },
+
+    { "name": "pr:coding", "color": "0e8a16", "description": "PR pipeline: a coder agent is on this PR" },
+    { "name": "pr:in-review", "color": "0e8a16", "description": "PR pipeline: a reviewer agent is on this PR" },
+    { "name": "pr:needs-attention", "color": "b60205", "description": "PR pipeline stalled — a human needs to look" }
+  ]
+}

--- a/.github/labels.schema.json
+++ b/.github/labels.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "label manifest",
+  "description": "The versioned set of labels the agent pipeline's state machine relies on. Synced idempotently into a consumer repo by .github/scripts/install/sync-labels.sh (installer workflow). The sync is additive: labels absent from the manifest are left untouched.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "labels"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Bump on any change to the label set. Reported by the sync so a consumer can see which manifest version it last applied."
+    },
+    "labels": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "color"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^(status|type|size|priority|pr):[A-Za-z-]+$",
+            "description": "prefix:value — the prefix groups the label in the state machine."
+          },
+          "color": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{6}$",
+            "description": "6-hex-digit color, no leading '#'."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 100
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/scripts/install/pr-body.md
+++ b/.github/scripts/install/pr-body.md
@@ -1,0 +1,21 @@
+## Install the interns pipeline
+
+Opened by the **Install interns** workflow.
+
+- **Labels** — the versioned manifest is already synced to this repo (that step
+  runs unconditionally, not in this PR).
+- **Caller stubs** — `.github/workflows/{issue,code}-pipeline.yml` delegate to
+  the reusable cores in `abi83/interns`, pinned to a release tag.
+- **Config** — `.github/agent-pipeline.yml` holds per-agent limits; every key is
+  optional and falls back to the interns defaults.
+
+Existing files were left untouched — re-running the installer only adds what is
+missing and re-syncs label drift.
+
+### Before merging
+
+- Add the `CLAUDE_CODE_OAUTH_TOKEN` and `REVIEWER_APP_PRIVATE_KEY` secrets and
+  the `REVIEWER_APP_ID` variable.
+- Turn on default-branch protection.
+
+See the interns README for the full prerequisite list.

--- a/.github/scripts/install/stage-stubs.sh
+++ b/.github/scripts/install/stage-stubs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copy the interns caller stubs + starter config into the current repo, but
+# only files that don't already exist — a re-run never clobbers a hand-edited
+# one. Optionally drop in the default issue templates when the repo has none.
+#
+# Usage: stage-stubs.sh <interns-checkout-dir> [install-issue-templates]
+#   install-issue-templates: "true" to add templates/issue/* when the repo
+#   has no .github/ISSUE_TEMPLATE/ (default: false)
+#
+# Emits `changed=<0|1>` to $GITHUB_OUTPUT (or stdout when unset).
+
+set -euo pipefail
+
+INTERNS_DIR="${1:?stage-stubs: interns checkout dir required}"
+INSTALL_TEMPLATES="${2:-false}"
+
+[[ -d "$INTERNS_DIR" ]] || { echo "stage-stubs: no such dir: $INTERNS_DIR" >&2; exit 1; }
+
+changed=0
+
+copy_if_absent() {
+  local src="$1" dest="$2"
+  if [[ -e "$dest" ]]; then
+    echo "skip (exists): $dest"
+    return
+  fi
+  mkdir -p "$(dirname "$dest")"
+  cp "$src" "$dest"
+  echo "add: $dest"
+  changed=1
+}
+
+copy_if_absent "$INTERNS_DIR/templates/workflows/issue-pipeline.yml" .github/workflows/issue-pipeline.yml
+copy_if_absent "$INTERNS_DIR/templates/workflows/code-pipeline.yml"  .github/workflows/code-pipeline.yml
+copy_if_absent "$INTERNS_DIR/templates/config/agent-pipeline.yml"    .github/agent-pipeline.yml
+
+if [[ "$INSTALL_TEMPLATES" == "true" && ! -d .github/ISSUE_TEMPLATE ]]; then
+  mkdir -p .github/ISSUE_TEMPLATE
+  cp "$INTERNS_DIR"/templates/issue/*.md "$INTERNS_DIR"/templates/issue/config.yml .github/ISSUE_TEMPLATE/
+  echo "add: .github/ISSUE_TEMPLATE/ (from interns defaults)"
+  changed=1
+fi
+
+echo "changed=$changed" >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/scripts/install/sync-labels.sh
+++ b/.github/scripts/install/sync-labels.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Sync the versioned label manifest (.github/labels.json) into a repo,
+# idempotently: create labels that are missing, update colour/description
+# when they've drifted, leave everything else alone.
+#
+# Additive by design — a label that isn't in the manifest is never deleted,
+# so a consumer's own labels survive a sync. Re-running with no manifest
+# changes is a no-op.
+#
+# Usage: sync-labels.sh [manifest-file]   (default: .github/labels.json)
+#
+# Env: GH_TOKEN (issues: write), GITHUB_REPOSITORY.
+
+set -euo pipefail
+
+MANIFEST="${1:-.github/labels.json}"
+
+die() { echo "sync-labels: $*" >&2; exit 1; }
+
+[[ -f "$MANIFEST" ]] || die "no such manifest: $MANIFEST"
+: "${GH_TOKEN:?sync-labels: GH_TOKEN unset}"
+: "${GITHUB_REPOSITORY:?sync-labels: GITHUB_REPOSITORY unset}"
+
+jq -e '(.version | type == "number") and (.labels | type == "array")' \
+  "$MANIFEST" >/dev/null || die "malformed manifest: $MANIFEST"
+
+version=$(jq -r '.version' "$MANIFEST")
+existing=$(gh label list --repo "$GITHUB_REPOSITORY" --limit 500 \
+  --json name,color,description)
+
+created=0 updated=0 unchanged=0
+
+while IFS=$'\t' read -r name color desc; do
+  current=$(jq -c --arg n "$name" 'map(select(.name == $n)) | first // empty' \
+    <<<"$existing")
+
+  if [[ -z "$current" ]]; then
+    gh label create "$name" --repo "$GITHUB_REPOSITORY" \
+      --color "$color" --description "$desc"
+    created=$((created + 1))
+    continue
+  fi
+
+  cur_color=$(jq -r '.color' <<<"$current")
+  cur_desc=$(jq -r '.description // ""' <<<"$current")
+  if [[ "${cur_color,,}" == "${color,,}" && "$cur_desc" == "$desc" ]]; then
+    unchanged=$((unchanged + 1))
+    continue
+  fi
+
+  gh label edit "$name" --repo "$GITHUB_REPOSITORY" \
+    --color "$color" --description "$desc"
+  updated=$((updated + 1))
+done < <(jq -r '.labels[] | [.name, .color, (.description // "")] | @tsv' "$MANIFEST")
+
+echo "sync-labels: manifest v${version} -> ${GITHUB_REPOSITORY}: ${created} created, ${updated} updated, ${unchanged} unchanged"

--- a/.github/scripts/install/tests/stage-stubs.bats
+++ b/.github/scripts/install/tests/stage-stubs.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+#
+# Tests for stage-stubs.sh — runs against a throwaway repo tree and a fake
+# interns checkout, both under $BATS_TEST_TMPDIR.
+
+setup() {
+  SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/stage-stubs.sh"
+
+  INTERNS="$BATS_TEST_TMPDIR/interns"
+  mkdir -p "$INTERNS/templates/workflows" "$INTERNS/templates/config" "$INTERNS/templates/issue"
+  echo "issue-stub"  > "$INTERNS/templates/workflows/issue-pipeline.yml"
+  echo "code-stub"   > "$INTERNS/templates/workflows/code-pipeline.yml"
+  echo "config-stub" > "$INTERNS/templates/config/agent-pipeline.yml"
+  echo "bug"         > "$INTERNS/templates/issue/bug.md"
+  echo "cfg"         > "$INTERNS/templates/issue/config.yml"
+
+  REPO="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$REPO"
+  cd "$REPO"
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/gh-output"
+  : > "$GITHUB_OUTPUT"
+}
+
+changed() { grep -oE 'changed=[01]' "$GITHUB_OUTPUT" | tail -1; }
+
+@test "copies every stub into a bare repo" {
+  run "$SCRIPT" "$INTERNS"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$REPO/.github/workflows/issue-pipeline.yml")" = "issue-stub" ]
+  [ "$(cat "$REPO/.github/workflows/code-pipeline.yml")" = "code-stub" ]
+  [ "$(cat "$REPO/.github/agent-pipeline.yml")" = "config-stub" ]
+  [ "$(changed)" = "changed=1" ]
+}
+
+@test "never overwrites an existing file" {
+  mkdir -p "$REPO/.github/workflows"
+  echo "MINE" > "$REPO/.github/workflows/issue-pipeline.yml"
+  run "$SCRIPT" "$INTERNS"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$REPO/.github/workflows/issue-pipeline.yml")" = "MINE" ]
+  [[ "$output" == *"skip (exists)"* ]]
+}
+
+@test "changed=0 when everything is already present" {
+  "$SCRIPT" "$INTERNS" >/dev/null
+  : > "$GITHUB_OUTPUT"
+  run "$SCRIPT" "$INTERNS"
+  [ "$status" -eq 0 ]
+  [ "$(changed)" = "changed=0" ]
+}
+
+@test "issue templates added only when asked and dir absent" {
+  run "$SCRIPT" "$INTERNS" true
+  [ "$status" -eq 0 ]
+  [ "$(cat "$REPO/.github/ISSUE_TEMPLATE/bug.md")" = "bug" ]
+}
+
+@test "issue templates skipped when the dir already exists" {
+  mkdir -p "$REPO/.github/ISSUE_TEMPLATE"
+  run "$SCRIPT" "$INTERNS" true
+  [ "$status" -eq 0 ]
+  [ ! -e "$REPO/.github/ISSUE_TEMPLATE/bug.md" ]
+}
+
+@test "issue templates skipped when not asked" {
+  run "$SCRIPT" "$INTERNS" false
+  [ "$status" -eq 0 ]
+  [ ! -d "$REPO/.github/ISSUE_TEMPLATE" ]
+}
+
+@test "fails when the interns dir is missing" {
+  run "$SCRIPT" "$BATS_TEST_TMPDIR/nope"
+  [ "$status" -ne 0 ]
+}

--- a/.github/scripts/install/tests/sync-labels.bats
+++ b/.github/scripts/install/tests/sync-labels.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+#
+# Tests for sync-labels.sh — a PATH-shadowing `gh` stub records every call and
+# serves a canned `gh label list` payload from $STUB_LABEL_LIST.
+
+setup() {
+  SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/sync-labels.sh"
+  STUB_BIN="$BATS_TEST_TMPDIR/bin"
+  STUB_LOG="$BATS_TEST_TMPDIR/calls.log"
+  mkdir -p "$STUB_BIN"
+  : >"$STUB_LOG"
+
+  cat >"$STUB_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"$STUB_LOG"
+if [[ "$1 $2" == "label list" ]]; then
+  echo "${STUB_LABEL_LIST:-[]}"
+fi
+exit 0
+EOF
+  chmod +x "$STUB_BIN/gh"
+  PATH="$STUB_BIN:$PATH"
+  export STUB_LOG
+
+  export GH_TOKEN=x GITHUB_REPOSITORY=owner/repo
+  MANIFEST="$BATS_TEST_TMPDIR/labels.json"
+  cat >"$MANIFEST" <<'EOF'
+{ "version": 7, "labels": [
+  { "name": "status:ready", "color": "0e8a16", "description": "go" },
+  { "name": "pr:coding", "color": "0e8a16", "description": "on it" }
+] }
+EOF
+}
+
+calls() { cat "$STUB_LOG"; }
+
+@test "creates every label when the repo has none" {
+  export STUB_LABEL_LIST='[]'
+  run "$SCRIPT" "$MANIFEST"
+  [ "$status" -eq 0 ]
+  [[ "$(calls)" == *"label create status:ready --repo owner/repo --color 0e8a16 --description go"* ]]
+  [[ "$(calls)" == *"label create pr:coding "* ]]
+  [[ "$output" == *"2 created, 0 updated, 0 unchanged"* ]]
+}
+
+@test "updates a drifted label and leaves a matching one alone" {
+  export STUB_LABEL_LIST='[
+    {"name":"status:ready","color":"cccccc","description":"go"},
+    {"name":"pr:coding","color":"0e8a16","description":"on it"}
+  ]'
+  run "$SCRIPT" "$MANIFEST"
+  [ "$status" -eq 0 ]
+  [[ "$(calls)" == *"label edit status:ready --repo owner/repo --color 0e8a16 --description go"* ]]
+  [[ "$(calls)" != *"label edit pr:coding"* ]]
+  [[ "$(calls)" != *"label create"* ]]
+  [[ "$output" == *"0 created, 1 updated, 1 unchanged"* ]]
+}
+
+@test "case-insensitive colour compare — no spurious update" {
+  export STUB_LABEL_LIST='[
+    {"name":"status:ready","color":"0E8A16","description":"go"},
+    {"name":"pr:coding","color":"0e8a16","description":"on it"}
+  ]'
+  run "$SCRIPT" "$MANIFEST"
+  [ "$status" -eq 0 ]
+  [[ "$(calls)" != *"label edit"* ]]
+  [[ "$output" == *"0 created, 0 updated, 2 unchanged"* ]]
+}
+
+@test "fails on a malformed manifest" {
+  echo '{ "nope": true }' >"$MANIFEST"
+  run "$SCRIPT" "$MANIFEST"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"malformed manifest"* ]]
+}
+
+@test "fails when GH_TOKEN is unset" {
+  unset GH_TOKEN
+  run "$SCRIPT" "$MANIFEST"
+  [ "$status" -ne 0 ]
+}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,118 @@
+name: Install interns
+
+# Provisions a consumer repo for the interns pipeline:
+#   1. syncs the versioned label manifest (unconditional)
+#   2. opens a PR with the thin caller stubs + a starter agent-pipeline.yml
+#   3. optionally drops in the default issue templates
+#
+# Callable two ways:
+#   - workflow_call, pinned to a tag, from a consumer repo's own wrapper
+#   - workflow_dispatch, from this repo, to (re-)sync abi83/interns' own labels
+#
+# Idempotent: re-running syncs label drift and skips stub files already present.
+
+on:
+  workflow_dispatch:
+    inputs:
+      open_pr:
+        description: Open the caller-stubs PR (vs. label sync only)
+        type: boolean
+        default: true
+      install_issue_templates:
+        description: Add default issue templates if the repo has none
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      ref:
+        description: interns ref to copy the manifest and templates from
+        required: false
+        type: string
+        default: v0.1.0
+      open_pr:
+        required: false
+        type: boolean
+        default: true
+      install_issue_templates:
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      INTERNS_REF: ${{ inputs.ref || github.sha }}
+    steps:
+      - name: Check out the consumer repo
+        uses: actions/checkout@v5
+
+      - name: Check out interns (manifest + templates)
+        # github.token must be able to read abi83/interns — true for a
+        # workflow_dispatch run in this repo, and for consumers in the same
+        # org with Actions repo-access configured. A cross-org consumer
+        # passes a PAT or App token here instead.
+        uses: actions/checkout@v5
+        with:
+          repository: abi83/interns
+          ref: ${{ env.INTERNS_REF }}
+          path: .interns
+
+      - name: Sync the label manifest
+        run: .interns/.github/scripts/install/sync-labels.sh .interns/.github/labels.json
+
+      - name: Stage caller stubs and starter config
+        if: ${{ inputs.open_pr }}
+        id: stage
+        run: |
+          set -euo pipefail
+          changed=0
+          copy_if_absent() {
+            local src="$1" dest="$2"
+            if [[ -e "$dest" ]]; then
+              echo "skip (exists): $dest"
+              return
+            fi
+            mkdir -p "$(dirname "$dest")"
+            cp "$src" "$dest"
+            echo "add: $dest"
+            changed=1
+          }
+
+          copy_if_absent .interns/templates/workflows/issue-pipeline.yml .github/workflows/issue-pipeline.yml
+          copy_if_absent .interns/templates/workflows/code-pipeline.yml .github/workflows/code-pipeline.yml
+          copy_if_absent .interns/templates/config/agent-pipeline.yml .github/agent-pipeline.yml
+
+          if [[ "${{ inputs.install_issue_templates }}" == "true" && ! -d .github/ISSUE_TEMPLATE ]]; then
+            mkdir -p .github/ISSUE_TEMPLATE
+            cp .interns/templates/issue/*.md .interns/templates/issue/config.yml .github/ISSUE_TEMPLATE/
+            echo "add: .github/ISSUE_TEMPLATE/ (from interns defaults)"
+            changed=1
+          fi
+
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Open the PR
+        if: ${{ inputs.open_pr && steps.stage.outputs.changed == '1' }}
+        run: |
+          set -euo pipefail
+          branch="interns/install-$(date +%Y%m%d%H%M%S)"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add .github/
+          git commit -m "chore: install interns pipeline caller stubs"
+          git push -u origin "$branch"
+          gh pr create --head "$branch" \
+            --title "Install the interns pipeline" \
+            --body-file .interns/.github/scripts/install/pr-body.md
+
+      - name: Nothing to open
+        if: ${{ inputs.open_pr && steps.stage.outputs.changed != '1' }}
+        run: echo "All caller stubs already present — labels synced, no PR needed."

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -14,6 +14,10 @@ name: Install interns
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: "interns ref for the manifest/templates (default: this run's ref)"
+        type: string
+        default: ""
       open_pr:
         description: Open the caller-stubs PR (vs. label sync only)
         type: boolean
@@ -25,10 +29,13 @@ on:
   workflow_call:
     inputs:
       ref:
-        description: interns ref to copy the manifest and templates from
+        description: >
+          interns ref to copy the manifest and templates from. Defaults to the
+          exact ref the caller pinned this workflow to, so the manifest always
+          matches the installer version. Override with a concrete tag if needed.
         required: false
         type: string
-        default: v0.1.0
+        default: ""
       open_pr:
         required: false
         type: boolean
@@ -48,8 +55,25 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
-      INTERNS_REF: ${{ inputs.ref || github.sha }}
     steps:
+      - name: Resolve the interns ref
+        id: ref
+        # Precedence: explicit input > the ref the caller pinned this reusable
+        # workflow to (github.job_workflow_ref, ".../install.yml@refs/tags/vX")
+        # > this run's own sha (the workflow_dispatch-on-this-repo case).
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.ref }}" ]]; then
+            ref="${{ inputs.ref }}"
+          elif [[ -n "${{ github.job_workflow_ref }}" ]]; then
+            ref="${{ github.job_workflow_ref }}"
+            ref="refs/${ref##*@refs/}"
+          else
+            ref="${{ github.sha }}"
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "Using interns ref: $ref"
+
       - name: Check out the consumer repo
         uses: actions/checkout@v5
 
@@ -61,7 +85,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: abi83/interns
-          ref: ${{ env.INTERNS_REF }}
+          ref: ${{ steps.ref.outputs.ref }}
           path: .interns
 
       - name: Sync the label manifest
@@ -70,39 +94,17 @@ jobs:
       - name: Stage caller stubs and starter config
         if: ${{ inputs.open_pr }}
         id: stage
-        run: |
-          set -euo pipefail
-          changed=0
-          copy_if_absent() {
-            local src="$1" dest="$2"
-            if [[ -e "$dest" ]]; then
-              echo "skip (exists): $dest"
-              return
-            fi
-            mkdir -p "$(dirname "$dest")"
-            cp "$src" "$dest"
-            echo "add: $dest"
-            changed=1
-          }
-
-          copy_if_absent .interns/templates/workflows/issue-pipeline.yml .github/workflows/issue-pipeline.yml
-          copy_if_absent .interns/templates/workflows/code-pipeline.yml .github/workflows/code-pipeline.yml
-          copy_if_absent .interns/templates/config/agent-pipeline.yml .github/agent-pipeline.yml
-
-          if [[ "${{ inputs.install_issue_templates }}" == "true" && ! -d .github/ISSUE_TEMPLATE ]]; then
-            mkdir -p .github/ISSUE_TEMPLATE
-            cp .interns/templates/issue/*.md .interns/templates/issue/config.yml .github/ISSUE_TEMPLATE/
-            echo "add: .github/ISSUE_TEMPLATE/ (from interns defaults)"
-            changed=1
-          fi
-
-          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+        run: >
+          .interns/.github/scripts/install/stage-stubs.sh
+          .interns "${{ inputs.install_issue_templates }}"
 
       - name: Open the PR
         if: ${{ inputs.open_pr && steps.stage.outputs.changed == '1' }}
         run: |
           set -euo pipefail
           branch="interns/install-$(date +%Y%m%d%H%M%S)"
+          # Canonical github-actions[bot] identity — the numeric id is what maps
+          # the noreply address to the bot account (same line as append-metrics.sh).
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"

--- a/.github/workflows/lint-pipeline.yml
+++ b/.github/workflows/lint-pipeline.yml
@@ -33,6 +33,12 @@ jobs:
           pipx run check-jsonschema --check-metaschema
           .github/agent-pipeline.schema.json
           .github/pipeline-metrics.schema.json
+          .github/labels.schema.json
+
+      - name: Validate the label manifest against its schema
+        run: >
+          pipx run check-jsonschema --schemafile
+          .github/labels.schema.json .github/labels.json
 
   test-scripts:
     runs-on: ubuntu-latest
@@ -42,3 +48,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y bats
       - name: Run pipeline script tests
         run: bats .github/scripts/pipeline/tests
+
+      - name: Run installer script tests
+        run: bats .github/scripts/install/tests

--- a/README.md
+++ b/README.md
@@ -39,11 +39,21 @@ Needs, in the consumer repo: `CLAUDE_CODE_OAUTH_TOKEN` +
 default-branch protection.
 Optional: `.github/agent-pipeline.yml` (per-agent model + limits).
 
-A one-shot installer that provisions all of that — a versioned label
-manifest plus prerequisite/safety checks — is tracked in
-[#4](https://github.com/abi83/interns/issues/4) /
-[#5](https://github.com/abi83/interns/issues/5). A fuller README —
-pipeline flow, label state table — is [#10](https://github.com/abi83/interns/issues/10).
+### Installer
+
+`.github/workflows/install.yml` provisions a consumer repo. It syncs the
+versioned label manifest ([`.github/labels.json`](.github/labels.json) —
+every `status:*` / `type:*` / `size:*` / `priority:*` / `pr:*` the state
+machine relies on) and opens a PR with the thin caller stubs plus a starter
+`.github/agent-pipeline.yml`. It's idempotent: re-running fixes label drift
+and only adds stub files that are missing, never overwriting a hand-edited
+one. Label sync is additive — labels absent from the manifest are left
+alone.
+
+Prerequisite/safety checks (branch protection, secrets, Pages) are tracked
+in [#5](https://github.com/abi83/interns/issues/5). A fuller README —
+pipeline flow, label state table — is
+[#10](https://github.com/abi83/interns/issues/10).
 
 ## Pipeline metrics
 
@@ -70,8 +80,11 @@ fetch of `raw.githubusercontent.com/<owner>/<repo>/metrics/metrics.jsonl`.
 | `.github/actions/*` | composite actions the cores use |
 | `.github/scripts/pipeline/*` | pipeline steps (+ `bats` tests) |
 | `.github/scripts/gh-safe/*` | the narrow `gh` surface the agents may call |
+| `.github/scripts/install/*` | installer steps (label sync, + `bats` tests) |
+| `.github/labels.json` | versioned label manifest (+ `.schema.json`) |
 | `.github/prompts/*` | agent prompts, layered over the consumer's `CLAUDE.md` |
 | `templates/issue/*` | default issue templates |
+| `templates/workflows/*`, `templates/config/*` | caller stubs + starter config the installer commits |
 
 ## License
 

--- a/templates/config/agent-pipeline.yml
+++ b/templates/config/agent-pipeline.yml
@@ -1,0 +1,19 @@
+# interns pipeline config — per-agent execution limits.
+# Precedence: this file > org/repo Actions vars > the interns defaults.
+# Schema: abi83/interns/.github/agent-pipeline.schema.json
+# Everything here is optional; delete a key to fall back to the default.
+
+defaults:
+  max_turns: 40
+  timeout_minutes: 20
+  cost_warn_usd: 2.0
+
+agents:
+  refiner:
+    max_turns: 25
+  estimator:
+    max_turns: 20
+  coder:
+    timeout_minutes: 30
+  reviewer:
+    max_turns: 30

--- a/templates/workflows/code-pipeline.yml
+++ b/templates/workflows/code-pipeline.yml
@@ -1,0 +1,38 @@
+# Thin caller for the interns coder/reviewer pipeline.
+# Owns the triggers; delegates all logic to the reusable core, pinned to a tag.
+name: Coding agents
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number (coder phase)
+        required: false
+        type: string
+      pr_number:
+        description: PR number (reviewer phase)
+        required: false
+        type: string
+      fix_round:
+        description: Treat a coder dispatch as a reviewer fix round
+        required: false
+        type: boolean
+        default: false
+      phase:
+        description: coder | reviewer
+        required: false
+        type: string
+
+jobs:
+  pipeline:
+    uses: abi83/interns/.github/workflows/code-pipeline.yml@v0.1.0
+    secrets: inherit
+    with:
+      issue_number: ${{ inputs.issue_number }}
+      pr_number: ${{ inputs.pr_number }}
+      fix_round: ${{ inputs.fix_round || false }}
+      phase: ${{ inputs.phase }}

--- a/templates/workflows/issue-pipeline.yml
+++ b/templates/workflows/issue-pipeline.yml
@@ -1,0 +1,25 @@
+# Thin caller for the interns issue refine/estimate pipeline.
+# Owns the triggers; delegates all logic to the reusable core, pinned to a tag.
+name: Issue pipeline
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number
+        required: true
+        type: string
+      phase:
+        description: refine | estimate
+        required: true
+        type: string
+
+jobs:
+  pipeline:
+    uses: abi83/interns/.github/workflows/issue-pipeline.yml@v0.1.0
+    secrets: inherit
+    with:
+      issue_number: ${{ inputs.issue_number }}
+      phase: ${{ inputs.phase }}


### PR DESCRIPTION
Implements #4.

## What's here

### `.github/labels.json` — the versioned manifest
One file, one `version` int, every label the pipeline's state machine relies on: `status:*`, `type:*`, `size:*`, `priority:*`, `pr:*` — including `pr:coding`, `pr:in-review`, and `pr:needs-attention` (#20). Validated against `.github/labels.schema.json` by `lint-pipeline`.

### `.github/scripts/install/sync-labels.sh` — idempotent sync
Creates missing labels, updates colour/description drift, leaves everything else alone. **Additive**: a label not in the manifest is never deleted, so a consumer's own labels survive. Re-running with no manifest change is a no-op. `bats` tests under `.github/scripts/install/tests/`, wired into `lint-pipeline`.

### `.github/workflows/install.yml` — installer
- syncs the manifest **unconditionally** (needs `issues: write`)
- opens a PR with the thin caller stubs (`templates/workflows/*`) + a starter `.github/agent-pipeline.yml` (`templates/config/*`)
- re-runnable: only adds stub files that are absent, never clobbers a hand-edited one
- optional `install_issue_templates` input — drops in the default issue templates only when the repo has no `.github/ISSUE_TEMPLATE/`
- `workflow_dispatch` (dogfood on this repo) + `workflow_call` (consumers, pinned to a tag)

## Notes
- Prerequisite/safety checks (branch protection, secrets, Pages) are out of scope here — that is #5.
- The installer's `abi83/interns` checkout assumes `github.token` can read it (same-org consumers / dispatch on this repo); a cross-org consumer passes its own token.

## Test
- `actionlint`, `shellcheck -x`, and both `bats` suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
