### PR TITLE
feat(pipeline): mark escalated PRs pr:needs-attention (#20)

### DIFF
--- a/.github/scripts/pipeline/apply-verdict.sh
+++ b/.github/scripts/pipeline/apply-verdict.sh
@@ -6,8 +6,8 @@
 # status:needs-attention when a human is needed, closed on merge. There is no
 # "approved" issue state — an approved PR is found via its native review state,
 # and the pr:* label only marks which agent is currently working (none, once
-# the reviewer is done). The fix-round decision is read from the verdict, not a
-# label (#133).
+# the reviewer is done) or pr:needs-attention when the loop has given up. The
+# fix-round decision is read from the verdict, not a label (#133).
 #
 # max_fix_rounds: how many automatic coder fix rounds a PR gets before the loop
 # escalates to a human. Counts CHANGES_REQUESTED reviews (this run's verdict
@@ -44,7 +44,7 @@ case "$last_state" in
     rc_count=$(gh api "repos/$repo/pulls/$pr/reviews" \
       --jq '[.[] | select(.user.login==env.REVIEWER_BOT and .state=="CHANGES_REQUESTED")] | length')
     if [[ "$rc_count" -gt "$max_fix_rounds" ]]; then
-      set_pr_pipeline_label "$pr"
+      escalate_pr "$pr"
       [[ -n "$issue" ]] && set_issue_status "$issue" status:needs-attention
       gh pr comment "$pr" --repo "$repo" --body \
         "Second review still requests changes — the automatic fix round didn't converge. Escalating to a human. See the run: $(run_url)"
@@ -61,7 +61,7 @@ case "$last_state" in
     fi
     ;;
   *)
-    set_pr_pipeline_label "$pr"
+    escalate_pr "$pr"
     [[ -n "$issue" ]] && set_issue_status "$issue" status:needs-attention
     gh pr comment "$pr" --repo "$repo" --body \
       "Review run completed without submitting a recognized verdict — likely stopped partway through. See the run: $(run_url)"

--- a/.github/scripts/pipeline/flag-failure.sh
+++ b/.github/scripts/pipeline/flag-failure.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Common failure handler for the agent phases: send the issue to
-# status:needs-attention, clear any pr:* pipeline label, and post a comment
+# status:needs-attention, mark the PR pr:needs-attention (or just clear its
+# label on a fix-round crash, which escalates issue-side), and post a comment
 # linking the run.
 #
 # Usage: flag-failure.sh --noun <noun> [--issue N] [--pr N] [--fix-round]
@@ -29,8 +30,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# A review-job crash leaves the PR stuck with no verdict; mark it for a human.
+# A fix-round crash escalates on the issue side, so the PR just loses its label.
 if [[ -n "$pr" ]]; then
-  set_pr_pipeline_label "$pr"
+  if [[ "$fix_round" == true ]]; then
+    set_pr_pipeline_label "$pr"
+  else
+    escalate_pr "$pr"
+  fi
 fi
 if [[ -n "$issue" ]]; then
   set_issue_status "$issue" status:needs-attention

--- a/.github/scripts/pipeline/lib.sh
+++ b/.github/scripts/pipeline/lib.sh
@@ -44,11 +44,14 @@ set_issue_status() {
   return 0
 }
 
-# The PR label marking which agent is on it now.
-_PR_PIPELINE_LABELS=(pr:coding pr:in-review)
+# PR pipeline labels: which agent is on it now (pr:coding / pr:in-review), or
+# pr:needs-attention once the automation has escalated it to a human. Mutually
+# exclusive — set_pr_pipeline_label keeps only the target, so a coder/reviewer
+# pickup or an APPROVE (clear) drops a stale pr:needs-attention.
+_PR_PIPELINE_LABELS=(pr:coding pr:in-review pr:needs-attention)
 
-# Set the PR's pipeline label, or clear both when called with no label (the
-# reviewer is done and no agent is active). Only touches labels that change.
+# Set the PR's pipeline label, or clear all of them when called with no label
+# (the reviewer is done and no agent is active). Only touches labels that change.
 set_pr_pipeline_label() {
   local pr="$1" target="${2:-}" current label
   local base=(pr edit "$pr" --repo "$GITHUB_REPOSITORY")
@@ -65,4 +68,11 @@ set_pr_pipeline_label() {
     gh "${args[@]}" || true
   fi
   return 0
+}
+
+# Mark a PR as stuck: the pipeline has escalated it to a human and no agent is
+# working it. "list the PRs a human still needs to act on" is then just
+# `gh pr list --label pr:needs-attention`. Cleared by the next pickup or APPROVE.
+escalate_pr() {
+  set_pr_pipeline_label "$1" pr:needs-attention
 }

--- a/.github/scripts/pipeline/route-red-checks.sh
+++ b/.github/scripts/pipeline/route-red-checks.sh
@@ -14,7 +14,7 @@ pr="$1"
 issue="${2:-}"
 reason="$3"
 
-set_pr_pipeline_label "$pr"
+escalate_pr "$pr"
 gh pr comment "$pr" --repo "$GITHUB_REPOSITORY" --body \
   "Required checks are not green ($reason) — the reviewer won't run. The coder writes and runs tests before pushing, so this is being sent straight to a human rather than retried. Run: $(run_url)"
 if [[ -n "$issue" ]]; then

--- a/.github/scripts/pipeline/tests/apply-verdict.bats
+++ b/.github/scripts/pipeline/tests/apply-verdict.bats
@@ -5,10 +5,10 @@ setup() {
 }
 
 @test "APPROVED clears the pr label and tells the issue" {
-  export STUB_LAST_STATE=APPROVED STUB_PR_LABELS="pr:in-review"
+  export STUB_LAST_STATE=APPROVED STUB_PR_LABELS="pr:needs-attention"
   run "$PIPELINE_DIR/apply-verdict.sh" 12 34
   [ "$status" -eq 0 ]
-  grep -q 'gh pr edit 12 --repo owner/repo --remove-label pr:in-review' "$STUB_LOG"
+  grep -q 'gh pr edit 12 --repo owner/repo --remove-label pr:needs-attention' "$STUB_LOG"
   grep -q 'gh issue comment 34 .* Reviewer approved \[PR #12\](https://github.com/owner/repo/pull/12) — awaiting owner merge' "$STUB_LOG"
 }
 
@@ -20,9 +20,10 @@ setup() {
 }
 
 @test "second CHANGES_REQUESTED escalates and does not dispatch" {
-  export STUB_LAST_STATE=CHANGES_REQUESTED STUB_RC_COUNT=2
+  export STUB_LAST_STATE=CHANGES_REQUESTED STUB_RC_COUNT=2 STUB_PR_LABELS="pr:in-review"
   run "$PIPELINE_DIR/apply-verdict.sh" 12 34
   grep -q "didn't converge. Escalating to a human" "$STUB_LOG"
+  grep -q 'gh pr edit 12 --repo owner/repo --remove-label pr:in-review --add-label pr:needs-attention' "$STUB_LOG"
   ! grep -q 'gh workflow run' "$STUB_LOG"
 }
 
@@ -34,7 +35,8 @@ setup() {
 }
 
 @test "an unrecognized verdict flags for a human" {
-  export STUB_LAST_STATE=""
+  export STUB_LAST_STATE="" STUB_PR_LABELS="pr:in-review"
   run "$PIPELINE_DIR/apply-verdict.sh" 12 34
   grep -q "without submitting a recognized verdict" "$STUB_LOG"
+  grep -q 'gh pr edit 12 --repo owner/repo --remove-label pr:in-review --add-label pr:needs-attention' "$STUB_LOG"
 }

--- a/.github/scripts/pipeline/tests/flag-failure.bats
+++ b/.github/scripts/pipeline/tests/flag-failure.bats
@@ -12,14 +12,19 @@ setup() {
 }
 
 @test "review failure comments on the PR, not the issue" {
+  export STUB_PR_LABELS="pr:in-review"
   run "$PIPELINE_DIR/flag-failure.sh" --noun review --pr 4 --issue 9
   grep -q 'gh pr comment 4 .* Automated review failed' "$STUB_LOG"
+  grep -q 'gh pr edit 4 --repo owner/repo --remove-label pr:in-review --add-label pr:needs-attention' "$STUB_LOG"
   ! grep -q 'gh issue comment' "$STUB_LOG"
 }
 
 @test "fix-round failure posts the re-dispatch command on the issue" {
+  export STUB_PR_LABELS="pr:coding"
   run "$PIPELINE_DIR/flag-failure.sh" --noun implementation --issue 9 --pr 4 --fix-round
   grep -q 'gh issue comment 9 .*gh workflow run code-pipeline.yml -f phase=coder -f issue_number=9 -f fix_round=true' "$STUB_LOG"
+  grep -q 'gh pr edit 4 --repo owner/repo --remove-label pr:coding' "$STUB_LOG"
+  ! grep -q 'pr:needs-attention' "$STUB_LOG"
   ! grep -q 'Automated implementation failed' "$STUB_LOG"
 }
 

--- a/.github/scripts/pipeline/tests/lib.bats
+++ b/.github/scripts/pipeline/tests/lib.bats
@@ -53,3 +53,21 @@ setup() {
   [ "$status" -eq 0 ]
   ! grep -q "gh pr edit" "$STUB_LOG"
 }
+
+@test "escalate_pr swaps an agent label for pr:needs-attention" {
+  export STUB_PR_LABELS="pr:in-review"
+  run escalate_pr 3
+  grep -qF -- "gh pr edit 3 --repo owner/repo --remove-label pr:in-review --add-label pr:needs-attention" "$STUB_LOG"
+}
+
+@test "a pickup clears a stale pr:needs-attention" {
+  export STUB_PR_LABELS="pr:needs-attention"
+  run set_pr_pipeline_label 3 pr:coding
+  grep -qF -- "gh pr edit 3 --repo owner/repo --add-label pr:coding --remove-label pr:needs-attention" "$STUB_LOG"
+}
+
+@test "clearing removes pr:needs-attention" {
+  export STUB_PR_LABELS="pr:needs-attention"
+  run set_pr_pipeline_label 3
+  grep -qF -- "gh pr edit 3 --repo owner/repo --remove-label pr:needs-attention" "$STUB_LOG"
+}

--- a/.github/scripts/pipeline/tests/route-red-checks.bats
+++ b/.github/scripts/pipeline/tests/route-red-checks.bats
@@ -3,11 +3,11 @@ setup() {
   setup_stubs
 }
 
-@test "clears the pr label, comments, and flags the linked issue" {
+@test "marks the PR pr:needs-attention, comments, and flags the linked issue" {
   export STUB_PR_LABELS="pr:in-review" STUB_ISSUE_LABELS="status:in-progress"
   run "$PIPELINE_DIR/route-red-checks.sh" 8 19 '`test`=fail, `build`=pass'
   [ "$status" -eq 0 ]
-  grep -q 'gh pr edit 8 --repo owner/repo --remove-label pr:in-review' "$STUB_LOG"
+  grep -q 'gh pr edit 8 --repo owner/repo --remove-label pr:in-review --add-label pr:needs-attention' "$STUB_LOG"
   grep -q 'gh pr comment 8 .* Required checks are not green (`test`=fail, `build`=pass)' "$STUB_LOG"
   grep -q 'gh issue edit 19 --repo owner/repo --add-label status:needs-attention --remove-label status:in-progress' "$STUB_LOG"
 }


### PR DESCRIPTION
Closes #20.

## What

When the pipeline escalates a PR to a human — fix-loop cap, red `test`/`build` checks, an unrecognized reviewer verdict, or a review-job crash — it previously only touched the linked issue and *cleared* the PR's `pr:*` label. "No `pr:*` label" already means "brand-new PR" and "approved, awaiting merge", so a stuck PR was indistinguishable from those. This adds a positive marker so `gh pr list --label pr:needs-attention` answers which PRs need a human.

## Changes

- **`lib.sh`**: `pr:needs-attention` joins the mutually-exclusive `_PR_PIPELINE_LABELS` set, so `set_pr_pipeline_label` drops a stale `pr:needs-attention` on the next coder/reviewer pickup or on an APPROVE (clear). New `escalate_pr()` wrapper.
- **`apply-verdict.sh`**: fix-loop cap and the `*)` unrecognized-verdict case call `escalate_pr`.
- **`route-red-checks.sh`**: red-check routing calls `escalate_pr`.
- **`flag-failure.sh`**: a review-job crash (`--pr`, no `--fix-round`) calls `escalate_pr`; a fix-round crash still only clears the label since it escalates issue-side.
- **Bats**: coverage for each escalation path and for clear-on-pickup / clear-on-APPROVE.

## Acceptance criteria

- [x] Fix-loop cap, red-check routing, unrecognized verdict, review-job failure each add `pr:needs-attention`.
- [x] A coder/reviewer pickup or an APPROVE removes it.
- [x] `gh pr list --label pr:needs-attention` returns exactly the stuck PRs.
- [x] `pr:needs-attention` present in the #4 label manifest (already shipped in `.github/labels.json`).
- [ ] Wiki `Contributing.md` PR-label table — lives in the separate wiki repo, not editable from here; needs a follow-up.

All 84 pipeline bats tests pass; `shellcheck -x` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
