### PR TITLE
feat(pipeline): cap automatic reviewer runs per PR (#16)

### DIFF
--- a/.github/scripts/pipeline/check-review-cap.sh
+++ b/.github/scripts/pipeline/check-review-cap.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Hard ceiling on automatic reviewer runs for one PR, independent of the
+# coder<->reviewer fix-loop cap in apply-verdict.sh. After the fix loop
+# escalates, every further push still spawns a full LLM reviewer run; without a
+# ceiling that is unbounded spend on a PR that takes many commits to land.
+#
+# Counts the reviewer bot's own prior reviews on the PR. At or over
+# MAX_AUTOMATIC_REVIEWS_PER_PR it writes capped=true (the workflow then skips the
+# Claude reviewer step), posts a one-line notice, and marks the PR
+# pr:needs-attention so it stays discoverable. Otherwise capped=false.
+#
+# workflow_dispatch is an explicit human override and never calls this script.
+#
+# Usage: check-review-cap.sh <pr>
+#   Env: REVIEWER_BOT, MAX_AUTOMATIC_REVIEWS_PER_PR, GH_TOKEN
+
+set -euo pipefail
+# shellcheck source=.github/scripts/pipeline/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pr="$1"
+repo="$GITHUB_REPOSITORY"
+max="${MAX_AUTOMATIC_REVIEWS_PER_PR:-5}"
+
+count=$(gh api "repos/$repo/pulls/$pr/reviews" \
+  --jq '[.[] | select(.user.login==env.REVIEWER_BOT)] | length')
+
+if [[ "$count" -ge "$max" ]]; then
+  echo "capped=true" >> "$GITHUB_OUTPUT"
+  escalate_pr "$pr"
+  gh pr comment "$pr" --repo "$repo" --body \
+    "Automatic review limit ($max) reached — further review is manual. Run: $(run_url)"
+else
+  echo "capped=false" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/pipeline/tests/check-review-cap.bats
+++ b/.github/scripts/pipeline/tests/check-review-cap.bats
@@ -1,0 +1,46 @@
+setup() {
+  load helpers
+  setup_stubs
+  export REVIEWER_BOT="reviewer[bot]"
+  export MAX_AUTOMATIC_REVIEWS_PER_PR=5
+}
+
+# A reviews payload with $1 reviews by the reviewer bot plus one human review.
+reviews_fixture() {
+  local n="$1" out='[{"user":{"login":"somedev"},"state":"COMMENTED"}]'
+  for ((i = 0; i < n; i++)); do
+    out=$(jq -c '. + [{"user":{"login":"reviewer[bot]"},"state":"CHANGES_REQUESTED"}]' <<<"$out")
+  done
+  printf '%s' "$out"
+}
+
+@test "under the cap: capped=false, no comment, no label edit" {
+  export STUB_REVIEWS="$(reviews_fixture 4)"
+  run "$PIPELINE_DIR/check-review-cap.sh" 12
+  [ "$status" -eq 0 ]
+  grep -q '^capped=false$' "$GITHUB_OUTPUT"
+  ! grep -q 'gh pr comment' "$STUB_LOG"
+  ! grep -q 'gh pr edit' "$STUB_LOG"
+}
+
+@test "at the cap: capped=true, comments, marks pr:needs-attention" {
+  export STUB_REVIEWS="$(reviews_fixture 5)" STUB_PR_LABELS="pr:in-review"
+  run "$PIPELINE_DIR/check-review-cap.sh" 12
+  [ "$status" -eq 0 ]
+  grep -q '^capped=true$' "$GITHUB_OUTPUT"
+  grep -q 'gh pr comment 12 .* Automatic review limit (5) reached — further review is manual' "$STUB_LOG"
+  grep -q 'gh pr edit 12 --repo owner/repo --remove-label pr:in-review --add-label pr:needs-attention' "$STUB_LOG"
+}
+
+@test "over the cap also caps" {
+  export STUB_REVIEWS="$(reviews_fixture 7)"
+  run "$PIPELINE_DIR/check-review-cap.sh" 12
+  [ "$status" -eq 0 ]
+  grep -q '^capped=true$' "$GITHUB_OUTPUT"
+}
+
+@test "cap is configurable via MAX_AUTOMATIC_REVIEWS_PER_PR" {
+  export MAX_AUTOMATIC_REVIEWS_PER_PR=2 STUB_REVIEWS="$(reviews_fixture 2)"
+  run "$PIPELINE_DIR/check-review-cap.sh" 12
+  grep -q '^capped=true$' "$GITHUB_OUTPUT"
+}

--- a/.github/workflows/code-pipeline.yml
+++ b/.github/workflows/code-pipeline.yml
@@ -59,6 +59,11 @@ env:
   # which includes paths (e.g. .github/workflows/**) that claude-code-action
   # relocates out of the working tree, so `git diff` alone can't see them (#13).
   ALLOWED_PR_READ: "Bash(gh pr diff:*),Bash(gh pr view:*)"
+  # Hard ceiling on event-triggered reviewer runs per PR, independent of the
+  # coder<->reviewer fix-loop cap in apply-verdict.sh. Past this many reviews by
+  # the reviewer bot, further pushes skip the Claude reviewer and go to a human.
+  # workflow_dispatch bypasses it. Part of #16.
+  MAX_AUTOMATIC_REVIEWS_PER_PR: 5
 
 jobs:
   coder:
@@ -478,9 +483,21 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Hard ceiling on automatic reviews per PR (#16). Event-triggered only —
+      # workflow_dispatch is an explicit human override and never runs this.
+      - name: Enforce automatic review cap
+        id: cap
+        if: github.event_name == 'pull_request' && steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEWER_BOT: ${{ steps.ident.outputs.bot }}
+        run: >
+          .interns/.github/scripts/pipeline/check-review-cap.sh
+          "${{ github.event.pull_request.number }}"
+
       - name: Run Claude reviewer
         id: claude
-        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true'
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && steps.cap.outputs.capped != 'true'
         timeout-minutes: ${{ fromJSON(steps.cfg.outputs.timeout_minutes) }}
         uses: anthropics/claude-code-action@v1
         env:
@@ -505,7 +522,7 @@ jobs:
             --allowedTools "Read,Grep,Glob,Write,${{ env.ALLOWED_GIT_READ }},${{ env.ALLOWED_PR_READ }},${{ env.ALLOWED_CI_READ }},${{ env.ALLOWED_ISSUE_READ }},${{ env.ALLOWED_SUBMIT_REVIEW }},${{ env.ALLOWED_COMMENT_PR }}"
 
       - name: Report run cost
-        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && always() && steps.claude.outputs.execution_file != ''
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && steps.cap.outputs.capped != 'true' && always() && steps.claude.outputs.execution_file != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: >
@@ -517,7 +534,7 @@ jobs:
       - name: Extract run metrics
         id: metrics
         continue-on-error: true
-        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && always() && steps.claude.outputs.execution_file != ''
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && steps.cap.outputs.capped != 'true' && always() && steps.claude.outputs.execution_file != ''
         run: >
           .interns/.github/scripts/pipeline/extract-metrics.sh
           "${{ steps.claude.outputs.execution_file }}"
@@ -527,7 +544,7 @@ jobs:
           > "${{ runner.temp }}/metrics-reviewer.json"
 
       - name: Upload run metrics
-        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && steps.metrics.outcome == 'success'
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && steps.cap.outputs.capped != 'true' && steps.metrics.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: pipeline-metrics-reviewer
@@ -536,7 +553,7 @@ jobs:
           retention-days: 2
 
       - name: Apply reviewer verdict
-        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && success()
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && steps.cap.outputs.capped != 'true' && success()
         env:
           GH_TOKEN: ${{ github.token }}
           REVIEWER_BOT: ${{ steps.ident.outputs.bot }}
@@ -546,7 +563,7 @@ jobs:
           "${{ steps.linked.outputs.issue_number }}"
 
       - name: Write run summary
-        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && always() && steps.claude.outcome != 'skipped'
+        if: steps.checks.outputs.ok == 'true' && steps.check.outputs.skip != 'true' && steps.cap.outputs.capped != 'true' && always() && steps.claude.outcome != 'skipped'
         env:
           GH_TOKEN: ${{ github.token }}
           REVIEWER_BOT: ${{ steps.ident.outputs.bot }}


### PR DESCRIPTION
Closes #16.

## What

Adds a hard ceiling on **event-triggered** reviewer runs per PR, independent of
the coder↔reviewer fix-loop cap in `apply-verdict.sh`. After escalation, every
further push to a PR still spawned a full LLM reviewer run with no limit — on a
PR that takes many commits to land, that is unbounded spend.

## Changes

- **`code-pipeline.yml`**
  - New `MAX_AUTOMATIC_REVIEWS_PER_PR` env var, default **5**.
  - New `Enforce automatic review cap` step in the reviewer job, gated on
    `github.event_name == 'pull_request'` so `workflow_dispatch` bypasses it.
  - The Claude reviewer step and its cost / metrics / verdict / summary steps
    now also require `steps.cap.outputs.capped != 'true'`.
- **`.github/scripts/pipeline/check-review-cap.sh`** (new) — counts the reviewer
  bot's prior reviews on the PR (`repos/.../pulls/{n}/reviews`). At or over the
  cap: writes `capped=true`, calls `escalate_pr` (adds `pr:needs-attention`,
  #20), and posts `Automatic review limit (N) reached — further review is manual`.
- **Bats** (`tests/check-review-cap.bats`) — under cap runs; at/over cap skips
  with a comment + label and no Claude call; cap is configurable.

## Acceptance criteria

- [x] `MAX_AUTOMATIC_REVIEWS_PER_PR` in `code-pipeline.yml`, default 5
- [x] Event-triggered runs 1..N proceed; run N+1 is skipped with a PR comment and no Claude call
- [x] `workflow_dispatch` runs the reviewer regardless of count
- [x] The skip path adds `pr:needs-attention`
- [ ] Wiki `Contributing.md` reviewer section — left for the wiki repo, same as #20

## Testing

`bats .github/scripts/pipeline/tests/` — all 88 pass. `shellcheck` clean
(pre-existing SC1091 info only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
