### PR TITLE
feat(pipeline): refiner investigates and flags blockers; estimator grounds scores in code

### DIFF
--- a/.github/prompts/estimate.md
+++ b/.github/prompts/estimate.md
@@ -16,21 +16,29 @@ risk, review, and anything an agent can't verify itself. Size against that
 reality, not generic story points or dev-days.
 
 You have read access to the repository (checked out at the working
-directory) and any contributor guide or wiki it ships. Read code and docs
-when it would sharpen the estimate — whether Scope reuses an existing
-pattern (smaller) or needs a new one (bigger), whether the architecture
-implies more moving parts than the issue text suggests. Don't guess about
-the codebase when you can check it.
+directory) and any contributor guide or wiki it ships. Sizing is a
+judgement about the code, not about the issue text — so read the code
+first. Before scoring, open the files, patterns, and wiki pages the Scope
+would touch: whether it reuses an existing pattern (smaller) or needs a new
+one (bigger), whether the architecture implies more moving parts than the
+issue text suggests, how much shared state sits near the change. Don't
+guess about the codebase when you can check it.
+
+The refiner's analysis comment covers blockers and dependencies only. It
+does **not** contain a risk assessment, and you do not inherit one — the
+Blast Radius score below is yours to derive from what you read in the code.
 
 Read Scope and Acceptance Criteria, then score each of these four criteria
-Low / Mid / High, weighted equally, with one sentence of reasoning grounded
-in the specific Scope or Acceptance Criteria content — not a restatement of
-the issue:
+Low / Mid / High, weighted equally. Each score needs one sentence of
+reasoning that **names the specific file, pattern, or wiki page you read**
+to reach it — not a restatement of the issue, and not reasoning from the
+issue text alone. If you couldn't find a concrete anchor for a score, say
+what you looked for and didn't find:
 
-- **Blast Radius** — risk of breaking something that already works. Auth,
-  data migrations, payment-adjacent flows, and anything touching
-  shared/prod state score High; an isolated new module or pure addition
-  scores Low.
+- **Blast Radius** — risk of breaking something that already works, which
+  you judge yourself from the code the change touches. Auth, data
+  migrations, payment-adjacent flows, and anything touching shared/prod
+  state score High; an isolated new module or pure addition scores Low.
 - **Touch** — roughly how many files/modules need to change, and how much
   context an agent (and a reviewer) has to hold at once. A single-file
   change is Low; a change spanning several modules, or a migration plus app
@@ -53,10 +61,10 @@ unsizeable mix, is XL.
 
 Output exactly this format:
 
-BLAST RADIUS: <Low|Mid|High> — <one sentence>
-TOUCH: <Low|Mid|High> — <one sentence>
-HUMAN INVOLVEMENT: <Low|Mid|High> — <one sentence>
-REVIEW OVERHEAD: <Low|Mid|High> — <one sentence>
+BLAST RADIUS: <Low|Mid|High> — <one sentence naming the code you read>
+TOUCH: <Low|Mid|High> — <one sentence naming the code you read>
+HUMAN INVOLVEMENT: <Low|Mid|High> — <one sentence naming the code you read>
+REVIEW OVERHEAD: <Low|Mid|High> — <one sentence naming the code you read>
 SIZE: <XS|S|M|L|XL>
 <one sentence on which criterion or criteria drove the size>
 

--- a/.github/prompts/refine.md
+++ b/.github/prompts/refine.md
@@ -2,6 +2,10 @@ You are refining a GitHub issue draft before it enters the backlog.
 
 Input: the raw issue title and body, plus any comments already on it.
 
+Refinement is two things, in this order: **investigate** the draft against
+the codebase, then **rewrite** the body from what you found. A refined
+issue is not just a reshaped draft — it is a draft checked against reality.
+
 ## Step 1: pick the type
 
 Four issue types exist. Determine which one applies:
@@ -34,18 +38,41 @@ exists:
 Ignore the YAML frontmatter and HTML comments; they're authoring guidance,
 not body content.
 
-## Step 2: fill it in
-
-Rewrite the body into the chosen structure, carrying over every concrete
-requirement already in the original text — you are clarifying and
-structuring, not inventing new scope. Leave HTML comments (`<!-- ... -->`)
-out of the final output; they're authoring guidance, not content.
+## Step 2: investigate
 
 You have read access to the repository (checked out at the working
-directory), and to any contributor guide or wiki it ships. Read code and
-docs to ground the refinement in what actually exists — whether something
-is already built, what an existing pattern looks like, what stated
-direction says. Use this to write a more accurate Scope, not to expand it.
+directory) and to any contributor guide or wiki it ships. Before writing
+anything, work out what the draft is actually asking for against what
+already exists:
+
+- **What already exists** — is any part of this built already, or
+  half-built? What is the current behaviour the ticket wants to change?
+- **What pattern it would reuse** — find the closest existing thing (a
+  module, a workflow job, a script, a doc section) and note how a change
+  like this one is normally shaped here.
+- **What it touches** — which files, jobs, configs, or wiki pages the work
+  would have to change or depend on.
+- **What stated direction says** — a parent epic, the README, the wiki, a
+  design issue it's part of.
+
+Keep a note of the specific files and wiki pages you open — Step 4 has to
+cite them.
+
+Use this to write a more accurate and *narrower* Scope. Investigation
+sharpens the ticket; it does not license adding scope the draft didn't ask
+for.
+
+## Step 3: rewrite the body
+
+Rewrite the body into the chosen structure, carrying over every concrete
+requirement already in the original text. Ground each section in what Step
+2 found — name the real files, jobs, and patterns rather than describing
+the work abstractly.
+
+The rewritten description must be **concise and specific** — tighter than
+the draft you were given, not longer. Cut restatement, hedging, and
+background the owner already knows. A refined Scope is a short list of
+concrete changes, each pointing at where it lands.
 
 Rules:
 
@@ -56,8 +83,36 @@ Rules:
   question. Do not guess at business intent.
 - Do not resolve ambiguity by picking the more ambitious interpretation.
   Prefer the smaller, more literal reading when the text is unclear.
+- Leave HTML comments (`<!-- ... -->`) out of the final output.
 - Output only the rewritten issue body in markdown. No preamble, no
   meta-commentary, no code fences wrapping the whole thing.
+
+## Step 4: post the analysis comment
+
+After the body is edited, post exactly one comment on the issue recording
+what the investigation turned up about **blockers and dependencies** —
+things that decide whether this ticket can be picked up now or has to wait:
+
+- other open issues it depends on or that must land first;
+- prerequisites that aren't built yet;
+- ordering constraints against other in-flight work;
+- external or console work the ticket implicitly needs (a secret, a
+  dashboard change, a provider setting).
+
+Rules for the comment:
+
+- Ground every point in what you actually checked. Cite the specific files
+  and wiki pages — "no rate-limit helper under `.github/scripts/pipeline/`",
+  not "there may not be a helper".
+- If the investigation found no blockers, say that in one line — still
+  naming what you checked to be sure.
+- **No risk assessment.** Blast radius, review cost, and effort are the
+  estimator's job, not yours. Stick to what blocks the work, not how hard
+  or dangerous it is.
+- Follow the consumer repo's `CLAUDE.md` prose rules: state facts rather
+  than claiming authority, use a table for any comparison, make each point
+  once.
+- Keep it short. This is a triage note, not a report.
 
 ## When to stop instead of refining
 
@@ -74,3 +129,6 @@ editing the body:
    exist yet (an unbuilt system, an undecided design, a blocked
    dependency), so scoping it now would be guesswork. Say what's missing
    and that refinement should wait until it lands.
+
+In the stop case, post only the clarification comment — no separate
+analysis comment, and don't touch the body.

--- a/.github/scripts/pipeline/agent-config.sh
+++ b/.github/scripts/pipeline/agent-config.sh
@@ -24,6 +24,10 @@ config="${AGENT_PIPELINE_CONFIG:-.github/agent-pipeline.yml}"
 known_agents=" refiner estimator coder reviewer "
 known_keys=" model max_turns timeout_minutes max_output_tokens cost_warn_usd "
 
+# The refiner runs a codebase investigation pass before rewriting the issue
+# body, so the whole pipeline defaults to claude-sonnet-5 rather than a
+# cheaper model. A consumer can still drop it per phase via
+# agents.refiner.model in the config file or the PIPELINE_MODEL Actions var.
 builtin_default() {
   case "$1" in
     model)             echo "claude-sonnet-5" ;;

--- a/.github/scripts/pipeline/tests/agent-config.bats
+++ b/.github/scripts/pipeline/tests/agent-config.bats
@@ -39,6 +39,13 @@ out() { grep "^$1=" "$GITHUB_OUTPUT" | cut -d= -f2-; }
   [ "$(out max_turns)" = "40" ]
 }
 
+@test "refiner defaults to claude-sonnet-5 for its investigation pass" {
+  export AGENT_PIPELINE_CONFIG="$BATS_TEST_TMPDIR/none.yml"
+  run "$PIPELINE_DIR/agent-config.sh" refiner
+  [ "$status" -eq 0 ]
+  [ "$(out model)" = "claude-sonnet-5" ]
+}
+
 @test "Actions var is the middle layer between file and built-in" {
   export AGENT_PIPELINE_CONFIG="$BATS_TEST_TMPDIR/none.yml"
   PIPELINE_MODEL=my-model run "$PIPELINE_DIR/agent-config.sh" reviewer

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -133,12 +133,17 @@ jobs:
             Then stop. Do not edit the body in this case.
 
             Otherwise, in order:
-            1. Write the new body to ./.issue-pipeline-body.md
+            1. Investigate the draft against the repo and wiki (refine.md
+               Step 2), then write the new body to ./.issue-pipeline-body.md
             2. Run ./.interns/.github/scripts/gh-safe/edit-issue-body.sh (no args)
-            3. Swap labels:
+            3. Write the blockers/dependencies analysis (refine.md Step 4)
+               to ./.issue-pipeline-comment.md and run
+               ./.interns/.github/scripts/gh-safe/comment-issue.sh (no args)
+            4. Swap labels:
                ./.interns/.github/scripts/gh-safe/edit-issue-labels.sh --remove-label "status:needs-refinement" --add-label "status:refined"
 
-            Do nothing else — no other comments, no other edits.
+            Post exactly the one analysis comment described in refine.md —
+            no other comments, no edits beyond the body and labels.
           claude_args: |
             --model ${{ steps.cfg.outputs.model }}
             --max-turns ${{ steps.cfg.outputs.max_turns }}

--- a/templates/config/agent-pipeline.yml
+++ b/templates/config/agent-pipeline.yml
@@ -9,6 +9,8 @@ defaults:
   cost_warn_usd: 2.0
 
 agents:
+  # The refiner defaults to claude-sonnet-5 (it investigates the codebase
+  # before rewriting) — set `model:` here to override per phase.
   refiner:
     max_turns: 25
   estimator:


### PR DESCRIPTION
Closes #22.

## Refiner — investigate first, then rewrite

- `refine.md` is restructured into an explicit flow: pick type → **investigate** the draft against the repo/wiki (what exists, what pattern it reuses, what it touches) → **rewrite** the body from that understanding, concise and specific (tighter than the draft, not longer) → **post one analysis comment**.
- The analysis comment lists **blockers and dependencies only** (other issues, unbuilt prerequisites, ordering constraints, external/console work), each grounded in the specific files/wiki pages checked. Risk assessment is explicitly excluded — that stays the estimator's job.
- `issue-pipeline.yml` refine job: ordered step list updated to include the comment; the "no other comments/edits" restriction is relaxed to "exactly the one analysis comment". Clarification-stop path is unchanged (still swaps to `status:needs-attention`, body untouched, and now explicitly posts no analysis comment).

## Model default

The pipeline built-in default is already `claude-sonnet-5`; `agent-config.sh` now documents that the refiner relies on it for the investigation pass, and it stays overridable per phase via `agents.refiner.model` or `PIPELINE_MODEL`. The starter config template notes the same. A new bats test locks the refiner default. The `estimate` phase model is untouched.

## Estimator — reason from the code

- `estimate.md` now requires each of the four scores to name the specific file/pattern/wiki page it was grounded in, and to say so explicitly when no concrete anchor was found.
- States that the refiner's comment carries no risk section and that Blast Radius is the estimator's own to derive from the code.

## Verification

- `bats .github/scripts/pipeline/tests` — 89 pass (incl. new refiner-default test)
- `shellcheck -x` clean on `agent-config.sh`
- workflow YAML parses

Part of #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
