### PR TITLE
feat(install): prerequisite and safety checks (#5)

### DIFF
--- a/.github/agent-pipeline.schema.json
+++ b/.github/agent-pipeline.schema.json
@@ -5,6 +5,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "allow_agent_push_to_default_branch": {
+      "type": "boolean",
+      "default": false,
+      "description": "Installer safety knob. When false (default) the installer requires — and creates if absent — default-branch protection that blocks the pipeline's bot identities from pushing directly."
+    },
     "defaults": { "$ref": "#/definitions/limits" },
     "agents": {
       "type": "object",

--- a/.github/scripts/install/safety-checks.sh
+++ b/.github/scripts/install/safety-checks.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# Installer safety gate. The pipeline runs with the consumer repo's own
+# credentials, so before the first run three things must hold:
+#
+#   1. The default branch is protected against direct pushes, so no agent
+#      identity can land code without a human-approved PR. Created with a
+#      baseline (require a PR, 1 approval, no force pushes/deletions) when
+#      absent -- unless `allow_agent_push_to_default_branch: true` in the
+#      config opts out.
+#   2. The pipeline's secrets exist. Their values can't be set from here, so a
+#      definitively missing one is a hard failure with instructions.
+#   3. GitHub Pages is enabled (the dashboard's deploy target). Switched on
+#      with the "GitHub Actions" build type when absent.
+#
+# Every check is reported; the script exits non-zero if any of them fails or
+# can't be repaired, and the installer step then fails with it.
+#
+# Managing branch protection and listing secrets need more than the default
+# GITHUB_TOKEN grants. Pass a token with repo-admin scope as GH_TOKEN to have
+# those checks enforced; without it they report what they can and warn where
+# they're blind, but a definitively unprotected branch or a definitively
+# missing secret is still a hard failure.
+#
+# Usage: safety-checks.sh
+# Env:   GH_TOKEN            repo token (admin scope enforces every check)
+#        GITHUB_REPOSITORY   owner/name
+#        AGENT_PIPELINE_CONFIG  config path (default .github/agent-pipeline.yml)
+#        REQUIRED_SECRETS      space-separated override of the secret list
+#        PIPELINE_BOT_LOGINS   space-separated extra bot logins to reject from
+#                              a branch-protection push allowlist
+
+set -euo pipefail
+
+CONFIG="${AGENT_PIPELINE_CONFIG:-.github/agent-pipeline.yml}"
+REQUIRED_SECRETS="${REQUIRED_SECRETS:-CLAUDE_CODE_OAUTH_TOKEN REVIEWER_APP_PRIVATE_KEY}"
+# github-actions[bot] and claude[bot] both push branches during a run; neither
+# (nor the reviewer App) may be granted a path to the default branch.
+BOT_LOGINS="github-actions[bot] claude[bot] ${PIPELINE_BOT_LOGINS:-}"
+
+: "${GH_TOKEN:?safety-checks: GH_TOKEN unset}"
+: "${GITHUB_REPOSITORY:?safety-checks: GITHUB_REPOSITORY unset}"
+
+say()  { echo "safety-checks: $*"; }
+fail() { failures+=("$*"); echo "safety-checks: FAIL: $*" >&2; }
+
+failures=()
+
+api() { gh api -H "Accept: application/vnd.github+json" "$@"; }
+
+# Run an api call, leaving the response body in $api_body and the outcome in
+# $api_state: "ok" (2xx), "missing" (404), or "blocked" (anything else,
+# typically a 403 from a token without the scope). Not run in a subshell, so
+# both globals are visible to the caller.
+api_body="" api_state=""
+api_status() {
+  local err
+  err=$(mktemp)
+  if api_body=$(api "$@" 2>"$err"); then
+    api_state=ok
+  elif grep -q 'HTTP 404' "$err"; then
+    api_state=missing
+  else
+    api_state=blocked
+  fi
+  rm -f "$err"
+}
+
+config_allows_agent_push() {
+  [[ -f "$CONFIG" ]] || return 1
+  [[ "$(yq -r '.allow_agent_push_to_default_branch // false' "$CONFIG" 2>/dev/null)" == "true" ]]
+}
+
+check_branch_protection() {
+  local branch granted bot ok=1
+  branch=$(api "repos/$GITHUB_REPOSITORY" --jq '.default_branch') || {
+    fail "could not read the default branch"
+    return
+  }
+
+  api_status "repos/$GITHUB_REPOSITORY/branches/$branch/protection"
+  case "$api_state" in
+    ok)
+      if [[ "$(jq -r '.required_pull_request_reviews // "null"' <<<"$api_body")" == "null" ]]; then
+        fail "branch '$branch' is protected but does not require a pull request review"
+        return
+      fi
+      granted=$(jq -r '
+        [ (.restrictions.users[]?.login), ("@" + .restrictions.teams[]?.slug),
+          (.restrictions.apps[]?.slug + "[bot]") ] | .[]' <<<"$api_body")
+      for bot in $BOT_LOGINS; do
+        if grep -qxF "$bot" <<<"$granted"; then
+          fail "branch '$branch' push allowlist grants '$bot'"
+          ok=0
+        fi
+      done
+      if [[ "$ok" -eq 1 ]]; then say "branch protection on '$branch': ok"; fi
+      return
+      ;;
+    blocked)
+      fail "can't read branch protection for '$branch' -- GH_TOKEN needs repo-admin scope"
+      return
+      ;;
+  esac
+
+  # A definitive 404: the branch has no protection.
+  if config_allows_agent_push; then
+    say "branch '$branch' is unprotected; allow_agent_push_to_default_branch is set, skipping"
+    return
+  fi
+
+  say "branch '$branch' is unprotected; applying the baseline"
+  if api -X PUT "repos/$GITHUB_REPOSITORY/branches/$branch/protection" --input - >/dev/null <<'JSON'
+{
+  "required_status_checks": null,
+  "enforce_admins": false,
+  "required_pull_request_reviews": { "required_approving_review_count": 1 },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+  then
+    say "branch protection on '$branch': created"
+  else
+    fail "branch '$branch' is unprotected and the baseline could not be applied -- GH_TOKEN needs repo-admin scope"
+  fi
+}
+
+check_secrets() {
+  local present name missing=()
+  # One list call: the default GITHUB_TOKEN can't read secrets, so treat an
+  # outright failure as "can't verify" (a warning) rather than "all missing".
+  if ! present=$(api "repos/$GITHUB_REPOSITORY/actions/secrets" \
+      --paginate --jq '.secrets[].name' 2>/dev/null); then
+    say "WARNING: can't list repo secrets (token lacks the scope) -- verify manually: $REQUIRED_SECRETS"
+    return
+  fi
+  for name in $REQUIRED_SECRETS; do
+    grep -qxF "$name" <<<"$present" || missing+=("$name")
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    fail "missing repo secret(s): ${missing[*]} -- add them under Settings > Secrets and variables > Actions"
+  else
+    say "required secrets present: $REQUIRED_SECRETS"
+  fi
+}
+
+check_pages() {
+  api_status "repos/$GITHUB_REPOSITORY/pages"
+  case "$api_state" in
+    ok)      say "GitHub Pages: enabled"; return ;;
+    blocked) fail "can't read GitHub Pages state -- GH_TOKEN needs 'pages' (or admin) scope"; return ;;
+  esac
+  say "GitHub Pages is off; enabling with the GitHub Actions build type"
+  if api -X POST "repos/$GITHUB_REPOSITORY/pages" -f "build_type=workflow" >/dev/null 2>&1; then
+    say "GitHub Pages: enabled"
+  else
+    fail "GitHub Pages could not be enabled -- turn it on under Settings > Pages"
+  fi
+}
+
+check_branch_protection
+check_secrets
+check_pages
+
+if [[ ${#failures[@]} -gt 0 ]]; then
+  echo >&2
+  say "${#failures[@]} safety check(s) failed -- install aborted" >&2
+  exit 1
+fi
+say "all safety checks passed"

--- a/.github/scripts/install/tests/safety-checks.bats
+++ b/.github/scripts/install/tests/safety-checks.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+#
+# Tests for safety-checks.sh — a PATH-shadowing `gh` stub logs every call and
+# serves canned GitHub API responses driven by STUB_* env vars.
+
+setup() {
+  SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/safety-checks.sh"
+  STUB_BIN="$BATS_TEST_TMPDIR/bin"
+  STUB_LOG="$BATS_TEST_TMPDIR/calls.log"
+  mkdir -p "$STUB_BIN"
+  : >"$STUB_LOG"
+
+  cat >"$STUB_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"$STUB_LOG"
+args="$*"
+notfound() { echo "gh: Not Found (HTTP 404)" >&2; exit 1; }
+blocked()  { echo "gh: Resource not accessible by integration (HTTP 403)" >&2; exit 1; }
+case "$args" in
+  *"-X PUT"*"/protection"*)  exit "${STUB_PUT_EXIT:-0}" ;;
+  *"-X POST"*"/pages"*)      exit "${STUB_PAGES_POST_EXIT:-0}" ;;
+  *"/branches/"*"/protection"*)
+    [[ "${STUB_PROTECTION_BLOCKED:-0}" == 1 ]] && blocked
+    [[ -n "${STUB_PROTECTION:-}" ]] || notfound
+    printf '%s' "$STUB_PROTECTION"; exit 0 ;;
+  *"/actions/secrets"*)
+    [[ "${STUB_SECRETS_LIST_FAIL:-0}" == 1 ]] && blocked
+    printf '%s\n' ${STUB_SECRETS:-}; exit 0 ;;
+  *"/pages"*)
+    [[ "${STUB_PAGES_BLOCKED:-0}" == 1 ]] && blocked
+    [[ "${STUB_PAGES_ON:-0}" == 1 ]] && exit 0
+    notfound ;;
+  *"repos/owner/repo"*)
+    printf '%s' "${STUB_DEFAULT_BRANCH:-main}"; exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB_BIN/gh"
+  PATH="$STUB_BIN:$PATH"
+  export STUB_LOG
+
+  export GH_TOKEN=x GITHUB_REPOSITORY=owner/repo
+  export AGENT_PIPELINE_CONFIG="$BATS_TEST_TMPDIR/agent-pipeline.yml"
+
+  # Happy-path defaults; individual tests override.
+  export STUB_PROTECTION='{"required_pull_request_reviews":{"required_approving_review_count":1},"restrictions":null}'
+  export STUB_SECRETS="CLAUDE_CODE_OAUTH_TOKEN REVIEWER_APP_PRIVATE_KEY"
+  export STUB_PAGES_ON=1
+}
+
+calls() { cat "$STUB_LOG"; }
+
+@test "passes when protection, secrets and Pages are all in place" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"all safety checks passed"* ]]
+  [[ "$(calls)" != *"-X PUT"* ]]
+  [[ "$(calls)" != *"-X POST"* ]]
+}
+
+@test "applies the baseline when the default branch is unprotected" {
+  unset STUB_PROTECTION
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(calls)" == *"-X PUT repos/owner/repo/branches/main/protection"* ]]
+  [[ "$output" == *"branch protection on 'main': created"* ]]
+}
+
+@test "fails when the branch is unprotected and the baseline cannot be applied" {
+  unset STUB_PROTECTION
+  export STUB_PUT_EXIT=1
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"baseline could not be applied"* ]]
+}
+
+@test "skips the baseline when the config opts out" {
+  unset STUB_PROTECTION
+  printf 'allow_agent_push_to_default_branch: true\n' >"$AGENT_PIPELINE_CONFIG"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(calls)" != *"-X PUT"* ]]
+  [[ "$output" == *"skipping"* ]]
+}
+
+@test "fails when branch protection can't be read (token lacks admin)" {
+  export STUB_PROTECTION_BLOCKED=1
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"can't read branch protection"* ]]
+  [[ "$(calls)" != *"-X PUT"* ]]
+}
+
+@test "fails when Pages state can't be read (token lacks scope)" {
+  export STUB_PAGES_BLOCKED=1
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"can't read GitHub Pages state"* ]]
+  [[ "$(calls)" != *"-X POST"* ]]
+}
+
+@test "fails when protection does not require a pull request review" {
+  export STUB_PROTECTION='{"required_pull_request_reviews":null,"restrictions":null}'
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not require a pull request review"* ]]
+}
+
+@test "fails when a bot identity is on the push allowlist" {
+  export STUB_PROTECTION='{"required_pull_request_reviews":{"required_approving_review_count":1},"restrictions":{"users":[{"login":"github-actions[bot]"}],"teams":[],"apps":[]}}'
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"grants 'github-actions[bot]'"* ]]
+}
+
+@test "fails and names a missing secret" {
+  export STUB_SECRETS="CLAUDE_CODE_OAUTH_TOKEN"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing repo secret(s): REVIEWER_APP_PRIVATE_KEY"* ]]
+}
+
+@test "warns but does not fail when secrets can't be listed" {
+  export STUB_SECRETS_LIST_FAIL=1
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING: can't list repo secrets"* ]]
+}
+
+@test "enables Pages when it is off" {
+  export STUB_PAGES_ON=0
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(calls)" == *"-X POST repos/owner/repo/pages"* ]]
+  [[ "$output" == *"GitHub Pages: enabled"* ]]
+}
+
+@test "fails when Pages cannot be enabled" {
+  export STUB_PAGES_ON=0 STUB_PAGES_POST_EXIT=1
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Pages could not be enabled"* ]]
+}
+
+@test "reports every failure, not just the first" {
+  unset STUB_PROTECTION
+  export STUB_PUT_EXIT=1 STUB_SECRETS="" STUB_PAGES_ON=0 STUB_PAGES_POST_EXIT=1
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"3 safety check(s) failed"* ]]
+}
+
+@test "fails when GH_TOKEN is unset" {
+  unset GH_TOKEN
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/scripts/pipeline/agent-config.sh
+++ b/.github/scripts/pipeline/agent-config.sh
@@ -43,7 +43,12 @@ if [[ -f "$config" ]]; then
 
   while IFS= read -r k; do
     [[ -z "$k" ]] && continue
-    [[ "$k" == "defaults" || "$k" == "agents" ]] || die "unknown top-level key '$k' in $config"
+    # allow_agent_push_to_default_branch is an installer-only safety knob; it's
+    # valid in the shared config file but means nothing to the agents.
+    case "$k" in
+      defaults | agents | allow_agent_push_to_default_branch) ;;
+      *) die "unknown top-level key '$k' in $config" ;;
+    esac
   done < <(yq 'keys | .[]' "$config")
 
   while IFS= read -r k; do

--- a/.github/scripts/pipeline/tests/agent-config.bats
+++ b/.github/scripts/pipeline/tests/agent-config.bats
@@ -62,6 +62,13 @@ out() { grep "^$1=" "$GITHUB_OUTPUT" | cut -d= -f2-; }
   [[ "$output" == *"unknown top-level key 'junk'"* ]]
 }
 
+@test "tolerates the installer's allow_agent_push_to_default_branch knob" {
+  echo "allow_agent_push_to_default_branch: true" >>"$CONFIG"
+  run "$PIPELINE_DIR/agent-config.sh" coder
+  [ "$status" -eq 0 ]
+  [ "$(out max_turns)" = "60" ]
+}
+
 @test "rejects an unknown agent block" {
   printf '  tester: { max_turns: 5 }\n' >>"$CONFIG"
   run "$PIPELINE_DIR/agent-config.sh" coder

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -27,6 +27,13 @@ on:
         type: boolean
         default: false
   workflow_call:
+    secrets:
+      admin_token:
+        description: >
+          Repo-admin token for the safety checks (branch protection, secrets,
+          Pages). Optional — without it those checks run best-effort on
+          github.token and fail loudly on anything they can't verify.
+        required: false
     inputs:
       ref:
         description: >
@@ -49,6 +56,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  pages: write  # safety check enables Pages when it's off
 
 jobs:
   install:
@@ -90,6 +98,13 @@ jobs:
 
       - name: Sync the label manifest
         run: .interns/.github/scripts/install/sync-labels.sh .interns/.github/labels.json
+
+      # Refuses to finish if the default branch isn't protected against the bot
+      # identities, a required secret is missing, or Pages can't be enabled.
+      - name: Verify prerequisites and safety checks
+        env:
+          GH_TOKEN: ${{ secrets.admin_token || github.token }}
+        run: .interns/.github/scripts/install/safety-checks.sh
 
       - name: Stage caller stubs and starter config
         if: ${{ inputs.open_pr }}

--- a/README.md
+++ b/README.md
@@ -50,9 +50,18 @@ and only adds stub files that are missing, never overwriting a hand-edited
 one. Label sync is additive — labels absent from the manifest are left
 alone.
 
-Prerequisite/safety checks (branch protection, secrets, Pages) are tracked
-in [#5](https://github.com/abi83/interns/issues/5). A fuller README —
-pipeline flow, label state table — is
+Before opening the PR it runs safety checks and refuses to finish if one
+fails: the default branch must be protected so the agent identities can't
+push to it (it applies a baseline — require a PR, one approval, no force
+pushes — when protection is absent, unless
+`allow_agent_push_to_default_branch: true` in the config opts out); the
+`CLAUDE_CODE_OAUTH_TOKEN` and `REVIEWER_APP_PRIVATE_KEY` secrets must exist;
+and Pages is enabled (switched on with the GitHub Actions build type when
+off). Managing branch protection and Pages needs a token with `administration`
+scope; reading secrets needs more than `GITHUB_TOKEN` carries, so that check
+downgrades to a warning when it can't list them.
+
+A fuller README — pipeline flow, label state table — is
 [#10](https://github.com/abi83/interns/issues/10).
 
 ## Pipeline metrics
@@ -80,7 +89,7 @@ fetch of `raw.githubusercontent.com/<owner>/<repo>/metrics/metrics.jsonl`.
 | `.github/actions/*` | composite actions the cores use |
 | `.github/scripts/pipeline/*` | pipeline steps (+ `bats` tests) |
 | `.github/scripts/gh-safe/*` | the narrow `gh` surface the agents may call |
-| `.github/scripts/install/*` | installer steps (label sync, + `bats` tests) |
+| `.github/scripts/install/*` | installer steps (label sync, safety checks, + `bats` tests) |
 | `.github/labels.json` | versioned label manifest (+ `.schema.json`) |
 | `.github/prompts/*` | agent prompts, layered over the consumer's `CLAUDE.md` |
 | `templates/issue/*` | default issue templates |

--- a/templates/config/agent-pipeline.yml
+++ b/templates/config/agent-pipeline.yml
@@ -3,6 +3,11 @@
 # Schema: abi83/interns/.github/agent-pipeline.schema.json
 # Everything here is optional; delete a key to fall back to the default.
 
+# Safety: keep the agents off the default branch. Set true only if the repo's
+# branch protection already blocks the bot identities some other way — the
+# installer's safety check then skips creating the baseline protection.
+# allow_agent_push_to_default_branch: false
+
 defaults:
   max_turns: 40
   timeout_minutes: 20


### PR DESCRIPTION
Closes #5.

## What

Adds an installer safety gate (`.github/scripts/install/safety-checks.sh`), run
after the label sync and before the caller-stubs PR is opened. The installer
**refuses to finish** if any check fails.

### Checks

1. **Default-branch protection** binding the bot identities so they can't push
   directly. When protection is absent the script applies a baseline (require a
   PR + 1 approval, no force pushes / deletions) — unless the new
   `allow_agent_push_to_default_branch` config knob (default `false`) opts out.
   An existing protection is checked for a PR-review requirement and for any bot
   login on the push allowlist.
2. **Required secrets** present (`CLAUDE_CODE_OAUTH_TOKEN`,
   `REVIEWER_APP_PRIVATE_KEY`). Values can't be set from a workflow, so a
   definitively missing one is a hard failure with instructions.
3. **GitHub Pages** enabled — switched on with the GitHub Actions build type
   when off.

### Token scope

Branch protection and secret listing need more than `GITHUB_TOKEN` carries. The
checks distinguish *verified bad* from *couldn't check*: an unreadable
protection state fails loudly, an unlistable secrets API downgrades to a
warning. The reusable workflow takes an optional `admin_token` secret to
enforce everything; `pages: write` is added to the job so Pages works with the
default token.

### Config knob

`allow_agent_push_to_default_branch` is a new optional top-level key in
`.github/agent-pipeline.yml` (schema + starter template updated).
`agent-config.sh` now tolerates it.

## Tests

- `.github/scripts/install/tests/safety-checks.bats` — 14 cases (happy path,
  baseline creation, opt-out, each failure mode, token-blind degradation).
- `agent-config.bats` — asserts the new knob is accepted.
- `shellcheck`, `actionlint`, and the full `bats` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
