### PR TITLE
feat(install): interns-install CLI — provision bot Apps + secrets (#24)

### DIFF
--- a/.github/workflows/lint-pipeline.yml
+++ b/.github/workflows/lint-pipeline.yml
@@ -26,7 +26,9 @@ jobs:
 
       # -x so shellcheck follows the `source` of pipeline/lib.sh.
       - name: Lint standalone shell scripts
-        run: find .github/scripts -name '*.sh' -print0 | xargs -0 -r shellcheck -x
+        run: |
+          find .github/scripts -name '*.sh' -print0 | xargs -0 -r shellcheck -x
+          shellcheck install.sh
 
       - name: Validate the JSON schemas are well-formed
         run: >
@@ -51,3 +53,14 @@ jobs:
 
       - name: Run installer script tests
         run: bats .github/scripts/install/tests
+
+  test-installer-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run interns-install tests
+        working-directory: installer
+        run: PYTHONPATH=src python -m unittest discover -s tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.egg-info/
+.venv/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ Optional: `.github/agent-pipeline.yml` (per-agent model + limits).
 
 ### Installer
 
+For 0.1.0 the supported path is `interns-install` — a local, interactive CLI
+that does the two things a headless Actions run can't: mint the `interns-reviewer`
+and `interns-coder` GitHub Apps (an interactive browser click) and write the
+repo secrets/variables (`secrets: write` isn't grantable to `GITHUB_TOKEN`). It
+then hands off to `install.yml` for the rest.
+
+```sh
+curl -LsSf https://raw.githubusercontent.com/abi83/interns/v0.1.0/install.sh | sh
+```
+
+The bootstrap installs [`uv`](https://docs.astral.sh/uv/) if missing; with `uv`
+already present, run
+`uvx --from git+https://github.com/abi83/interns.git@v0.1.0#subdirectory=installer interns-install`.
+Needs the [GitHub CLI](https://cli.github.com/) authenticated with a token that
+can write repo secrets. Details and flags: [`installer/README.md`](installer/README.md).
+The fully manual path stays documented as the fallback.
+
 `.github/workflows/install.yml` provisions a consumer repo. It syncs the
 versioned label manifest ([`.github/labels.json`](.github/labels.json) —
 every `status:*` / `type:*` / `size:*` / `priority:*` / `pr:*` the state
@@ -97,6 +114,8 @@ fetch of `raw.githubusercontent.com/<owner>/<repo>/metrics/metrics.jsonl`.
 | `.github/prompts/*` | agent prompts, layered over the consumer's `CLAUDE.md` |
 | `templates/issue/*` | default issue templates |
 | `templates/workflows/*`, `templates/config/*` | caller stubs + starter config the installer commits |
+| `installer/` | `interns-install` — the local CLI for Apps + secrets (Python, stdlib only) |
+| `install.sh` | one-line bootstrap: ensures `uv`, runs `interns-install` |
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# interns installer bootstrap.
+#
+# The only shell in the install path: it runs before Python/uv exist. It
+# ensures `uv` is present (via Astral's official installer) and then hands
+# straight over to the Python CLI, which does the real work.
+#
+#   curl -LsSf https://raw.githubusercontent.com/abi83/interns/v0.1.0/install.sh | sh
+#
+# Args after `--` go to interns-install, e.g.
+#   curl -LsSf .../install.sh | sh -s -- --dry-run --repo owner/name
+#
+# Override the version with INTERNS_REF (branch, tag or sha).
+
+set -eu
+
+INTERNS_REF="${INTERNS_REF:-v0.1.0}"
+SPEC="git+https://github.com/abi83/interns.git@${INTERNS_REF}#subdirectory=installer"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "bootstrap: installing uv (https://docs.astral.sh/uv/)"
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # uv lands in ~/.local/bin (or XDG_BIN_HOME); make it reachable for this run.
+  export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$HOME/.cargo/bin:$PATH"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "bootstrap: the GitHub CLI (gh) is required and was not found." >&2
+  echo "           install it from https://cli.github.com/ and run 'gh auth login'." >&2
+  exit 1
+fi
+
+exec uvx --from "$SPEC" interns-install "$@"

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,62 @@
+# interns-install
+
+Interactive local front end for provisioning a repo for the interns pipeline.
+
+`install.yml` does everything a headless GitHub Actions run can — label sync,
+caller-stub PR, starter config, safety checks. It deliberately can't do the two
+things that keep setup heavy:
+
+- **create the bot GitHub Apps** — needs an interactive browser click
+- **write repo secrets / variables** — `secrets: write` isn't grantable to
+  `GITHUB_TOKEN`
+
+`interns-install` fills exactly that gap, then hands off to `install.yml`.
+
+## Run it
+
+```sh
+curl -LsSf https://raw.githubusercontent.com/abi83/interns/v0.1.0/install.sh | sh
+```
+
+The bootstrap installs [`uv`](https://docs.astral.sh/uv/) if missing and runs
+the CLI. With `uv` already present:
+
+```sh
+uvx --from git+https://github.com/abi83/interns.git@v0.1.0#subdirectory=installer interns-install
+```
+
+Prerequisites: the [GitHub CLI](https://cli.github.com/) authenticated
+(`gh auth login`) with a token that can write repo secrets — classic scope
+`repo`, or a fine-grained PAT with **Secrets: write** and **Variables: write**
+on the target repo. Python 3.12+ (managed by `uv`).
+
+## What it does
+
+1. Mints `interns-reviewer` and `interns-coder` via the GitHub App Manifest
+   flow — a localhost callback server, one "Create GitHub App" click per app.
+2. Writes `REVIEWER_APP_ID` / `CODER_APP_ID` (variables) and
+   `REVIEWER_APP_PRIVATE_KEY` / `CODER_APP_PRIVATE_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`
+   (secrets). Private keys go straight from the manifest conversion response
+   into the secret, never to disk.
+3. Dispatches `install.yml` (or prints the manual step if the target repo has
+   no wrapper yet).
+4. Prints a summary and a checklist of anything still manual — installing each
+   App on the repo, branch protection the token couldn't set.
+
+## Flags
+
+| flag | effect |
+|---|---|
+| `--repo OWNER/NAME` | target repo (default: what `gh` resolves for the cwd) |
+| `--yes` | assume yes for every prompt |
+| `--dry-run` | print every mutation without performing it |
+| `--issue-templates[=true\|false]` | ask `install.yml` to add the default issue templates |
+| `--handoff-ref REF` | ref to dispatch `install.yml` on (default: target default branch) |
+| `--skip-handoff` | don't touch `install.yml` |
+
+## Develop
+
+```sh
+cd installer
+PYTHONPATH=src python -m unittest discover -s tests -v
+```

--- a/installer/pyproject.toml
+++ b/installer/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "interns-install"
+version = "0.1.0"
+description = "Interactive local front end for provisioning a repo for the interns pipeline"
+readme = "README.md"
+requires-python = ">=3.12"
+license = "MIT"
+dependencies = []
+
+[project.scripts]
+interns-install = "interns_install.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/interns_install"]

--- a/installer/src/interns_install/__init__.py
+++ b/installer/src/interns_install/__init__.py
@@ -1,0 +1,3 @@
+"""interns-install: interactive local provisioning for the interns pipeline."""
+
+__version__ = "0.1.0"

--- a/installer/src/interns_install/__main__.py
+++ b/installer/src/interns_install/__main__.py
@@ -1,0 +1,5 @@
+import sys
+
+from .cli import main
+
+sys.exit(main())

--- a/installer/src/interns_install/apps.py
+++ b/installer/src/interns_install/apps.py
@@ -1,0 +1,159 @@
+"""GitHub App Manifest flow.
+
+Mints an App from a manifest: serve a self-submitting form, let the operator
+click "Create GitHub App" once, catch the redirect on a localhost callback,
+hand the code back for conversion.
+
+https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import secrets
+import threading
+import urllib.parse
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+# Permission matrix is fixed by the pipeline's needs (see README / #10):
+# push branches, open and review PRs, edit issues and labels, read check runs.
+APP_PERMISSIONS = {
+    "contents": "write",
+    "pull_requests": "write",
+    "issues": "write",
+    "checks": "read",
+    "metadata": "read",
+}
+
+
+@dataclass
+class AppSpec:
+    key: str            # "reviewer" / "coder"
+    default_name: str   # "interns-reviewer" / "interns-coder"
+    id_var: str         # "REVIEWER_APP_ID"
+    key_secret: str     # "REVIEWER_APP_PRIVATE_KEY"
+    description: str
+
+
+APPS = [
+    AppSpec(
+        key="reviewer",
+        default_name="interns-reviewer",
+        id_var="REVIEWER_APP_ID",
+        key_secret="REVIEWER_APP_PRIVATE_KEY",
+        description="submits PR reviews for the interns pipeline (claude[bot] can't approve its own PR)",
+    ),
+    AppSpec(
+        key="coder",
+        default_name="interns-coder",
+        id_var="CODER_APP_ID",
+        key_secret="CODER_APP_PRIVATE_KEY",
+        description="coder-side pushes, PRs, comments and label edits for the interns pipeline",
+    ),
+]
+
+
+def build_manifest(name: str, redirect_url: str, description: str) -> dict:
+    return {
+        "name": name,
+        "url": "https://github.com/abi83/interns",
+        "description": description,
+        "redirect_url": redirect_url,
+        "public": False,
+        "default_events": [],
+        "default_permissions": APP_PERMISSIONS,
+    }
+
+
+def settings_new_url(repo_owner: str, is_org: bool) -> str:
+    if is_org:
+        return f"https://github.com/organizations/{repo_owner}/settings/apps/new"
+    return "https://github.com/settings/apps/new"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "interns-install/0.1"
+
+    def log_message(self, *args):  # noqa: D401 - silence stdlib request logging
+        pass
+
+    def do_GET(self):  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+        if parsed.path == "/":
+            self._send_html(200, self.server.form_page)
+            return
+        if parsed.path == "/callback":
+            code = params.get("code", [None])[0]
+            state = params.get("state", [None])[0]
+            if not code or state != self.server.state:
+                self._send_html(400, "<p>Bad callback (state mismatch). You can close this tab.</p>")
+                return
+            self.server.code = code
+            self._send_html(
+                200,
+                "<p>App created. Return to your terminal — you can close this tab.</p>",
+            )
+            self.server.done.set()
+            return
+        self._send_html(404, "<p>Not found.</p>")
+
+    def _send_html(self, status: int, body: str):
+        payload = f"<!doctype html><meta charset=utf-8><body>{body}</body>".encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class ManifestServer:
+    """Context manager around a one-shot localhost callback server."""
+
+    def __init__(self, action_url: str, make_manifest):
+        """make_manifest(redirect_url) -> manifest dict. Called once the
+        callback port is known."""
+        self.state = secrets.token_urlsafe(24)
+        self._httpd = HTTPServer(("127.0.0.1", 0), _Handler)
+        self._httpd.state = self.state
+        self._httpd.code = None
+        self._httpd.done = threading.Event()
+        redirect_url = f"http://127.0.0.1:{self.port}/callback"
+        self.manifest = make_manifest(redirect_url)
+        self._httpd.form_page = self._render_form(action_url, self.manifest)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+
+    @property
+    def port(self) -> int:
+        return self._httpd.server_address[1]
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/"
+
+    def _render_form(self, action_url: str, manifest: dict) -> str:
+        manifest_json = html.escape(json.dumps(manifest), quote=True)
+        return (
+            "<!doctype html><meta charset=utf-8><body>"
+            "<p>Redirecting you to GitHub to create the App…</p>"
+            f'<form id=f action="{html.escape(action_url)}?state={self.state}" method=post>'
+            f'<input type=hidden name=manifest value="{manifest_json}">'
+            "<noscript><button type=submit>Continue to GitHub</button></noscript>"
+            "</form><script>document.getElementById('f').submit()</script>"
+            "</body>"
+        )
+
+    def __enter__(self):
+        self._thread.start()
+        return self
+
+    def wait_for_code(self, timeout: float = 600.0) -> str:
+        if not self._httpd.done.wait(timeout):
+            raise TimeoutError("timed out waiting for the GitHub App creation callback")
+        return self._httpd.code
+
+    def __exit__(self, *exc):
+        self._httpd.shutdown()
+        self._httpd.server_close()

--- a/installer/src/interns_install/cli.py
+++ b/installer/src/interns_install/cli.py
@@ -1,0 +1,177 @@
+"""`interns-install` — the interactive local half of interns setup.
+
+Covers exactly what a headless `install.yml` run cannot: minting the two bot
+GitHub Apps (an interactive browser click) and writing repo secrets/variables
+(`secrets: write` is not grantable to `GITHUB_TOKEN`). Everything else is
+handed off to `install.yml`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import webbrowser
+
+from . import gh
+from .apps import APPS, AppSpec, ManifestServer, build_manifest, settings_new_url
+from .console import Console
+
+WORKFLOW = "install.yml"
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="interns-install",
+        description="Provision a repo for the interns pipeline (bot identities + secrets).",
+    )
+    p.add_argument("--repo", metavar="OWNER/NAME",
+                   help="target repo (default: the repo `gh` resolves for the cwd)")
+    p.add_argument("--yes", action="store_true",
+                   help="assume yes for every prompt (non-interactive)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="print every mutation without performing it")
+    p.add_argument("--issue-templates", nargs="?", const="true", default="false",
+                   metavar="true|false",
+                   help="tell install.yml to add the default issue templates")
+    p.add_argument("--handoff-ref", metavar="REF",
+                   help="ref to dispatch install.yml on (default: target default branch)")
+    p.add_argument("--skip-handoff", action="store_true",
+                   help="don't dispatch or describe install.yml")
+    return p.parse_args(argv)
+
+
+def _scope_preflight(con: Console, repo: str) -> list[str] | None:
+    existing = gh.list_secret_names(repo)
+    if existing is None:
+        con.warn(
+            "your token can't list repo secrets — it is probably too narrow to "
+            "write them either. Re-auth with `gh auth login -s repo` (classic) "
+            "or a fine-grained PAT with Secrets: write, then re-run."
+        )
+        if not con.confirm("Continue anyway?", default=False):
+            sys.exit(1)
+    return existing
+
+
+def _secret_verb(name: str, existing: list[str] | None) -> str:
+    if existing is None:
+        return "set"
+    return "overwrite" if name in existing else "add"
+
+
+def _provision_app(con: Console, repo: gh.Repo, spec: AppSpec,
+                   existing_secrets: list[str] | None,
+                   existing_vars: list[str] | None) -> None:
+    con.step(f"GitHub App: {spec.default_name} ({spec.key})")
+    if not con.confirm(f"Create the App '{spec.default_name}' now?", default=True):
+        con.note_manual(f"create the {spec.key} App and set {spec.id_var} / {spec.key_secret}")
+        return
+
+    action_url = settings_new_url(repo.owner, repo.is_org)
+
+    if con.dry_run:
+        con.mutation(f"open {action_url} to create App '{spec.default_name}' via manifest")
+        con.mutation(f"{_secret_verb(spec.key_secret, existing_secrets)} secret {spec.key_secret}")
+        con.mutation(f"set variable {spec.id_var}")
+        con.note_manual(f"install the {spec.key} App on {repo.slug}")
+        return
+
+    with ManifestServer(action_url, lambda redirect: build_manifest(
+        spec.default_name, redirect, spec.description)) as server:
+        con.say(f"opening your browser to create '{spec.default_name}' — "
+                "click 'Create GitHub App' (rename it first if that name is taken)")
+        con.say(f"if nothing opened, visit: {server.base_url}")
+        webbrowser.open(server.base_url)
+        code = server.wait_for_code()
+
+    conv = gh.convert_manifest(code)
+    app_id = str(conv["id"])
+    slug = conv.get("slug", spec.default_name)
+    pem = conv["pem"]
+
+    # Resilient ordering: the private key is returned exactly once, so it goes
+    # straight into the secret before we do anything else.
+    if con.mutation(f"{_secret_verb(spec.key_secret, existing_secrets)} secret {spec.key_secret}"):
+        gh.set_secret(repo.slug, spec.key_secret, pem)
+    pem = None  # noqa: F841 - drop the only reference to the key
+
+    if con.mutation(f"set variable {spec.id_var} = {app_id}"):
+        gh.set_variable(repo.slug, spec.id_var, app_id)
+
+    con.say(f"App '{slug}' created (id {app_id})")
+    con.note_manual(
+        f"install the {spec.key} App on {repo.slug}: "
+        f"https://github.com/apps/{slug}/installations/new"
+    )
+
+
+def _write_oauth_token(con: Console, repo: gh.Repo, existing_secrets: list[str] | None) -> None:
+    con.step("Claude Code OAuth token")
+    if con.dry_run:
+        con.mutation(f"{_secret_verb('CLAUDE_CODE_OAUTH_TOKEN', existing_secrets)} "
+                     "secret CLAUDE_CODE_OAUTH_TOKEN")
+        return
+    token = con.prompt_secret("Paste the CLAUDE_CODE_OAUTH_TOKEN (leave blank to skip):")
+    if not token:
+        con.note_manual("set the CLAUDE_CODE_OAUTH_TOKEN secret")
+        return
+    if con.mutation(f"{_secret_verb('CLAUDE_CODE_OAUTH_TOKEN', existing_secrets)} "
+                    "secret CLAUDE_CODE_OAUTH_TOKEN"):
+        gh.set_secret(repo.slug, "CLAUDE_CODE_OAUTH_TOKEN", token)
+
+
+def _handoff(con: Console, repo: gh.Repo, args: argparse.Namespace) -> None:
+    con.step("Hand off to install.yml (labels, caller stubs, safety checks)")
+    inputs = {"install_issue_templates": args.issue_templates}
+
+    if not gh.workflow_exists(repo.slug, WORKFLOW):
+        con.note_manual(
+            f"add a thin wrapper that calls abi83/interns/.github/workflows/{WORKFLOW} "
+            f"(see the interns README), then run it — or `gh workflow run {WORKFLOW} "
+            f"--repo {repo.slug}` once present"
+        )
+        con.say(f"{WORKFLOW} is not in {repo.slug} yet — see the summary for the manual step")
+        return
+
+    ref = args.handoff_ref or _default_branch(repo)
+    if not con.confirm(f"Dispatch {WORKFLOW} on {repo.slug}@{ref} now?", default=True):
+        con.note_manual(f"run `gh workflow run {WORKFLOW} --repo {repo.slug} --ref {ref}`")
+        return
+    if con.mutation(f"dispatch {WORKFLOW} on {repo.slug}@{ref}"):
+        gh.dispatch_workflow(repo.slug, WORKFLOW, ref, inputs)
+
+
+def _default_branch(repo: gh.Repo) -> str:
+    data = gh.api(f"repos/{repo.slug}")
+    return data.get("default_branch", "main") if isinstance(data, dict) else "main"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    con = Console(assume_yes=args.yes, dry_run=args.dry_run)
+
+    try:
+        gh.ensure_available()
+        repo = gh.current_repo(args.repo)
+    except gh.GhError as exc:
+        con.error(str(exc))
+        return 1
+
+    con.say(f"target repo: {repo.slug}" + (" (dry run)" if args.dry_run else ""))
+
+    existing_secrets = _scope_preflight(con, repo.slug)
+    existing_vars = gh.list_variable_names(repo.slug)
+
+    try:
+        for spec in APPS:
+            _provision_app(con, repo, spec, existing_secrets, existing_vars)
+        _write_oauth_token(con, repo, existing_secrets)
+        if not args.skip_handoff:
+            _handoff(con, repo, args)
+    except (gh.GhError, TimeoutError) as exc:
+        con.error(str(exc))
+        con.summary()
+        return 1
+
+    con.summary()
+    return 0

--- a/installer/src/interns_install/console.py
+++ b/installer/src/interns_install/console.py
@@ -1,0 +1,75 @@
+"""Terminal I/O: status lines, prompts, and dry-run bookkeeping."""
+
+from __future__ import annotations
+
+import getpass
+import sys
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Console:
+    assume_yes: bool = False
+    dry_run: bool = False
+    planned: list[str] = field(default_factory=list)
+    manual: list[str] = field(default_factory=list)
+
+    def say(self, msg: str) -> None:
+        print(f"interns-install: {msg}")
+
+    def warn(self, msg: str) -> None:
+        print(f"interns-install: WARNING: {msg}", file=sys.stderr)
+
+    def error(self, msg: str) -> None:
+        print(f"interns-install: ERROR: {msg}", file=sys.stderr)
+
+    def step(self, msg: str) -> None:
+        print(f"\n→ {msg}")
+
+    def mutation(self, msg: str) -> bool:
+        """Record an outward change. Returns False when it must be skipped
+        (dry run), True when the caller should perform it."""
+        if self.dry_run:
+            self.planned.append(msg)
+            print(f"  [dry-run] would {msg}")
+            return False
+        self.planned.append(msg)
+        print(f"  {msg}")
+        return True
+
+    def note_manual(self, msg: str) -> None:
+        self.manual.append(msg)
+
+    def confirm(self, question: str, default: bool = False) -> bool:
+        if self.assume_yes:
+            return True
+        suffix = "Y/n" if default else "y/N"
+        try:
+            answer = input(f"{question} [{suffix}] ").strip().lower()
+        except EOFError:
+            return default
+        if not answer:
+            return default
+        return answer in ("y", "yes")
+
+    def prompt(self, question: str) -> str:
+        return input(f"{question} ").strip()
+
+    def prompt_secret(self, question: str) -> str:
+        return getpass.getpass(f"{question} ").strip()
+
+    def summary(self) -> None:
+        print("\n" + "=" * 60)
+        print("Summary")
+        print("=" * 60)
+        if self.planned:
+            label = "Would perform:" if self.dry_run else "Done:"
+            print(label)
+            for item in self.planned:
+                print(f"  - {item}")
+        else:
+            print("Nothing to do.")
+        if self.manual:
+            print("\nStill manual:")
+            for item in self.manual:
+                print(f"  - {item}")

--- a/installer/src/interns_install/gh.py
+++ b/installer/src/interns_install/gh.py
@@ -1,0 +1,137 @@
+"""Thin wrappers over the operator's authenticated `gh` CLI.
+
+All repo mutation in the installer goes through here, so it runs with the
+operator's own credentials — never a token written to disk.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+
+class GhError(RuntimeError):
+    pass
+
+
+def _run(args: list[str], *, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            ["gh", *args],
+            input=input_text,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+    except FileNotFoundError as exc:
+        raise GhError("the `gh` CLI is not installed or not on PATH") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip()
+        raise GhError(f"`gh {' '.join(args)}` failed: {detail}") from exc
+
+
+def ensure_available() -> None:
+    if shutil.which("gh") is None:
+        raise GhError("the `gh` CLI is not installed or not on PATH")
+    _run(["auth", "status"])
+
+
+def _parse_scopes(text: str) -> set[str]:
+    for line in text.splitlines():
+        marker = "Token scopes:"
+        if marker in line:
+            raw = line.split(marker, 1)[1]
+            return {s.strip().strip("'\"") for s in raw.split(",") if s.strip().strip("'\"")}
+    return set()
+
+
+def auth_scopes() -> set[str]:
+    """Classic-token scopes from `gh auth status`. Empty for a fine-grained
+    PAT (its permissions are not reported here)."""
+    proc = _run(["auth", "status"], check=False)
+    return _parse_scopes((proc.stderr or "") + (proc.stdout or ""))
+
+
+def api(path: str, *, method: str = "GET", fields: dict[str, str] | None = None,
+        input_json: str | None = None) -> object:
+    args = ["api", "-H", "Accept: application/vnd.github+json", "-X", method, path]
+    for key, value in (fields or {}).items():
+        args += ["-f", f"{key}={value}"]
+    if input_json is not None:
+        args += ["--input", "-"]
+    proc = _run(args, input_text=input_json)
+    out = proc.stdout.strip()
+    return json.loads(out) if out else None
+
+
+@dataclass
+class Repo:
+    owner: str
+    name: str
+    is_org: bool
+
+    @property
+    def slug(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+
+def current_repo(explicit: str | None) -> Repo:
+    args = ["repo", "view"]
+    if explicit:
+        args.append(explicit)
+    args += ["--json", "name,owner"]
+    data = json.loads(_run(args).stdout)
+    owner = data["owner"]["login"]
+    owner_type = data["owner"].get("type", "")
+    return Repo(owner=owner, name=data["name"], is_org=owner_type.lower() == "organization")
+
+
+def list_secret_names(repo: str) -> list[str] | None:
+    """None means the token cannot read the secret list (scope-blind)."""
+    try:
+        data = api(f"repos/{repo}/actions/secrets?per_page=100")
+    except GhError:
+        return None
+    return [s["name"] for s in (data or {}).get("secrets", [])]
+
+
+def list_variable_names(repo: str) -> list[str] | None:
+    try:
+        data = api(f"repos/{repo}/actions/variables?per_page=100")
+    except GhError:
+        return None
+    return [v["name"] for v in (data or {}).get("variables", [])]
+
+
+def set_secret(repo: str, name: str, value: str) -> None:
+    _run(["secret", "set", name, "--repo", repo, "--body", "-"], input_text=value)
+
+
+def set_variable(repo: str, name: str, value: str) -> None:
+    # `variable set` refuses to overwrite silently on some versions; delete-then-set is idempotent.
+    _run(["variable", "delete", name, "--repo", repo], check=False)
+    _run(["variable", "set", name, "--repo", repo, "--body", "-"], input_text=value)
+
+
+def convert_manifest(code: str) -> dict:
+    data = api(f"app-manifest/{code}/conversions", method="POST")
+    if not isinstance(data, dict) or "pem" not in data:
+        raise GhError("manifest conversion did not return a private key")
+    return data
+
+
+def workflow_exists(repo: str, workflow: str) -> bool:
+    try:
+        api(f"repos/{repo}/actions/workflows/{workflow}")
+        return True
+    except GhError:
+        return False
+
+
+def dispatch_workflow(repo: str, workflow: str, ref: str, inputs: dict[str, str]) -> None:
+    args = ["workflow", "run", workflow, "--repo", repo, "--ref", ref]
+    for key, value in inputs.items():
+        args += ["-f", f"{key}={value}"]
+    _run(args)

--- a/installer/tests/test_apps.py
+++ b/installer/tests/test_apps.py
@@ -1,0 +1,60 @@
+import unittest
+import urllib.error
+import urllib.request
+
+from interns_install.apps import (
+    APP_PERMISSIONS,
+    ManifestServer,
+    build_manifest,
+    settings_new_url,
+)
+
+
+class ManifestTests(unittest.TestCase):
+    def test_build_manifest_shape(self):
+        m = build_manifest("interns-coder", "http://127.0.0.1:5/callback", "desc")
+        self.assertEqual(m["name"], "interns-coder")
+        self.assertEqual(m["redirect_url"], "http://127.0.0.1:5/callback")
+        self.assertFalse(m["public"])
+        self.assertEqual(m["default_events"], [])
+        self.assertEqual(m["default_permissions"], APP_PERMISSIONS)
+
+    def test_settings_url_user_vs_org(self):
+        self.assertEqual(settings_new_url("alice", False),
+                         "https://github.com/settings/apps/new")
+        self.assertEqual(settings_new_url("acme", True),
+                         "https://github.com/organizations/acme/settings/apps/new")
+
+
+class ManifestServerTests(unittest.TestCase):
+    def _make(self):
+        return ManifestServer(
+            "https://github.com/settings/apps/new",
+            lambda redirect: build_manifest("interns-reviewer", redirect, "d"),
+        )
+
+    def test_form_page_carries_state_and_manifest(self):
+        with self._make() as server:
+            body = urllib.request.urlopen(server.base_url, timeout=5).read().decode()
+            self.assertIn(f"state={server.state}", body)
+            self.assertIn("name=manifest", body)
+            self.assertIn(f"127.0.0.1:{server.port}/callback", server.manifest["redirect_url"])
+
+    def test_callback_captures_code(self):
+        with self._make() as server:
+            url = f"{server.base_url}callback?code=abc123&state={server.state}"
+            urllib.request.urlopen(url, timeout=5).read()
+            self.assertEqual(server.wait_for_code(timeout=2), "abc123")
+
+    def test_callback_rejects_bad_state(self):
+        with self._make() as server:
+            url = f"{server.base_url}callback?code=abc123&state=wrong"
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                urllib.request.urlopen(url, timeout=5)
+            self.assertEqual(ctx.exception.code, 400)
+            with self.assertRaises(TimeoutError):
+                server.wait_for_code(timeout=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/installer/tests/test_cli.py
+++ b/installer/tests/test_cli.py
@@ -1,0 +1,44 @@
+import unittest
+
+from interns_install import gh
+from interns_install.cli import _parse_args, _secret_verb
+
+
+class ArgTests(unittest.TestCase):
+    def test_defaults(self):
+        a = _parse_args([])
+        self.assertIsNone(a.repo)
+        self.assertFalse(a.yes)
+        self.assertFalse(a.dry_run)
+        self.assertEqual(a.issue_templates, "false")
+        self.assertFalse(a.skip_handoff)
+
+    def test_issue_templates_bare_flag(self):
+        self.assertEqual(_parse_args(["--issue-templates"]).issue_templates, "true")
+        self.assertEqual(_parse_args(["--issue-templates=true"]).issue_templates, "true")
+
+    def test_repo_and_dry_run(self):
+        a = _parse_args(["--repo", "acme/widgets", "--dry-run", "--yes"])
+        self.assertEqual(a.repo, "acme/widgets")
+        self.assertTrue(a.dry_run)
+        self.assertTrue(a.yes)
+
+
+class SecretVerbTests(unittest.TestCase):
+    def test_verb(self):
+        self.assertEqual(_secret_verb("A", None), "set")
+        self.assertEqual(_secret_verb("A", []), "add")
+        self.assertEqual(_secret_verb("A", ["A"]), "overwrite")
+
+
+class ScopeParseTests(unittest.TestCase):
+    def test_parse_scopes(self):
+        text = "  - Token scopes: 'gist', 'read:org', 'repo'\n"
+        self.assertEqual(gh._parse_scopes(text), {"gist", "read:org", "repo"})
+
+    def test_no_scopes_line(self):
+        self.assertEqual(gh._parse_scopes("Logged in to github.com"), set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #24.

## What

`interns-install` — the local, interactive half of setup, covering exactly what a headless `install.yml` run can't:

1. **Mint the two bot GitHub Apps** (`interns-reviewer`, `interns-coder`) via the [App Manifest flow](https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest) — a one-shot localhost callback server, one "Create GitHub App" click per app.
2. **Write the secrets/variables** using the operator's own `gh auth`: `REVIEWER_APP_ID` / `CODER_APP_ID` (vars), `REVIEWER_APP_PRIVATE_KEY` / `CODER_APP_PRIVATE_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` (secrets).
3. **Hand off to `install.yml`** — `gh workflow run` when the target repo has it, else print the manual step.

Private keys go straight from the manifest conversion response into the secret (never to disk); the secret is written *before* the app-install step finishes, so a crash can't strand a one-time key. Secret/var writes are idempotent and report add vs. overwrite. Token-scope preflight warns before starting if the token can't write secrets.

## Deviation from the issue (agreed, see #24 comment)

**Python, not `npx`.** The repo is consolidating on one language (`.sh` → Python later); a JS CLI would split setup across two. Distribution:

```sh
curl -LsSf https://raw.githubusercontent.com/abi83/interns/v0.1.0/install.sh | sh
```

`install.sh` ensures `uv` (Astral's official installer) then `uvx --from git+https://github.com/abi83/interns.git@v0.1.0#subdirectory=installer interns-install`. It is the one shell script that outlives the migration — it runs before Python/uv exist. Issue #24 body and #10 updated to match.

App Manifest `default_permissions` requested: `contents:write`, `pull_requests:write`, `issues:write`, `checks:read`, `metadata:read` (the #10 matrix).

## Layout

| | |
|---|---|
| `installer/src/interns_install/{cli,gh,apps,console}.py` | CLI (stdlib only, `requires-python >=3.12`) |
| `installer/tests/` | `unittest` — manifest shape, callback server round-trip + state check, arg parsing, scope parsing |
| `install.sh` | bootstrap |
| `.github/workflows/lint-pipeline.yml` | `shellcheck install.sh`; new `test-installer-cli` job on py3.12 |

## Not in scope (per issue non-goals)

Org-scope provisioning, refiner/estimator identities, key rotation, anything `install.yml` / #5 own.

## Test

```sh
cd installer && PYTHONPATH=src python -m unittest discover -s tests -v
```

`interns-install --dry-run --repo abi83/interns` exercised locally (hits the real `gh` for the secret-list preflight and the `install.yml` existence check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
