### PR TITLE
docs: README as the 0.1.0 setup + operations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,204 @@ entirely in the consumer repo's GitHub Actions — no hosted service.
 Status: early. Consumed by [`abi83/prepify`](https://github.com/abi83/prepify).
 Design and roadmap: [#3](https://github.com/abi83/interns/issues/3).
 
-## Consuming it
+## What it does
 
-Commit two thin caller workflows that own the triggers and delegate to the
-reusable cores, pinned to an exact tag:
+Four agents pick issues up by label and hand them along a fixed track:
+
+| Agent | Trigger | Does | Leaves |
+|---|---|---|---|
+| **Refiner** | `status:needs-refinement` on an issue | picks the type, checks the draft against the codebase and wiki, rewrites the body into the type's template, posts a blockers/dependencies comment | `status:refined` |
+| **Estimator** | `status:refined` | reads the code the Scope touches, scores blast radius / touch / human involvement / review overhead, rolls that into a size | `status:estimated` + `size:*` |
+| **Coder** | `status:ready` (owner-approved) on a `type:coding-task` or `type:bug` | implements every Acceptance Criteria item, writes tests, opens a PR that `Closes #N` | `status:in-progress`, a PR labelled `pr:in-review` |
+| **Reviewer** | a PR opened/updated by the coder (or a human) | waits for the `test` / `build` checks, reviews the diff against the linked issue, submits `APPROVE` or `REQUEST_CHANGES` | PR approved, or a coder fix round, or `pr:needs-attention` |
+
+The human owner does two things: approve the estimate (move `status:estimated`
+→ `status:ready`), and merge the final PR. Everything between is automated, and
+anything the automation can't finish is parked on `status:needs-attention` /
+`pr:needs-attention` rather than guessed at.
+
+```mermaid
+flowchart TD
+    new([issue opened]) --> nr[status:needs-refinement]
+    nr -->|refiner| refined[status:refined]
+    nr -.->|needs a decision| na[status:needs-attention]
+    refined -->|estimator| est[status:estimated + size:*]
+    refined -.->|epic| ready
+    refined -.->|needs a decision| na
+    est -->|owner approves| ready[status:ready]
+    est -->|owner rejects| wrong[status:estimated-wrong]
+    wrong -.->|owner re-triggers| refined
+    ready -->|coder| inprog[status:in-progress]
+    inprog -->|PR opened| review[PR: pr:in-review]
+    review -->|reviewer: APPROVE| merge([owner merges → issue closed])
+    review -->|reviewer: REQUEST_CHANGES| fix[PR: pr:coding fix round]
+    fix -->|coder| review
+    review -.->|red checks / 2nd rejection / review cap| prna[PR: pr:needs-attention]
+    inprog -.->|no PR / coder declined| na
+```
+
+## Label state machine
+
+The installer syncs these from the versioned manifest
+([`.github/labels.json`](.github/labels.json)). Label sync is additive — labels
+not in the manifest are left alone.
+
+### `status:*` — issue lifecycle (mutually exclusive)
+
+| Label | Meaning | Set by | Moves to |
+|---|---|---|---|
+| `status:needs-refinement` | awaiting the refiner | human, on issue creation | `status:refined`, or `status:needs-attention` if the refiner needs a decision |
+| `status:refined` | refined, awaiting estimation | refiner | `status:estimated` (+ `size:*`); `status:ready` directly for a `type:epic`; `status:needs-attention` if unsizeable |
+| `status:estimated` | estimated, awaiting owner approval | estimator | `status:ready` (owner approves) or `status:estimated-wrong` (owner rejects) |
+| `status:estimated-wrong` | estimate rejected by the owner | human | owner edits the issue and re-triggers refinement/estimation |
+| `status:ready` | approved for the coder | **human** (this is the approval gate) | `status:in-progress` when the coder starts; `status:needs-attention` if the issue isn't a `type:coding-task` / `type:bug` |
+| `status:in-progress` | a coder run is working the issue (held for the whole run, fix rounds included) | coder | issue closed on merge, or `status:needs-attention` |
+| `status:needs-attention` | pipeline stalled — a human needs to look | any agent | cleared when a human re-dispatches (the coder drops it on pickup) |
+
+### `pr:*` — PR pipeline (mutually exclusive)
+
+| Label | Meaning | Set by | Moves to |
+|---|---|---|---|
+| `pr:coding` | a coder agent is on this PR (a fix round) | reviewer, when it requests changes | `pr:in-review` after the coder pushes |
+| `pr:in-review` | a reviewer agent is on this PR | coder, at hand-off | cleared on `APPROVE`; `pr:coding` on `REQUEST_CHANGES`; `pr:needs-attention` on escalation |
+| `pr:needs-attention` | PR pipeline stalled — a human needs to look | reviewer gate | cleared by the next agent pickup or an `APPROVE` |
+
+An approved PR carries **no** `pr:*` label — the native review state is the
+signal. List the PRs waiting on a human with
+`gh pr list --label pr:needs-attention`.
+
+### `type:*` — set by the refiner (or a human at creation), never changed after
+
+| Label | Estimated? | Coder implements? |
+|---|---|---|
+| `type:coding-task` | yes | yes |
+| `type:bug` | yes | yes |
+| `type:spike` | yes | no — investigation only |
+| `type:epic` | no — skipped straight to `status:ready` | no — breaks down into sub-issues |
+
+A `type:epic` or `type:spike` that reaches `status:ready` is bounced to
+`status:needs-attention` by the coder's type gate.
+
+### `size:*` and `priority:*`
+
+`size:XS` … `size:XL` are added by the estimator alongside `status:estimated`;
+`size:XL` also gets a `SPLIT:` note on the estimate comment. `priority:low` …
+`priority:urgent` are owner triage labels — the pipeline reads neither; they
+exist for humans sorting the backlog.
+
+## Setup
+
+### 1. Register the two GitHub Apps
+
+The pipeline runs the coder and the reviewer as **separate** GitHub App
+identities so the reviewer can actually `APPROVE` a PR the coder authored
+(GitHub forbids approving your own PR) and so branch protection can treat each
+independently.
+
+`interns-install` (below) mints both via the App Manifest flow. To create them
+by hand instead, make two apps — `interns-coder` and `interns-reviewer` — with
+the same permission set:
+
+| Permission | Access | Why |
+|---|---|---|
+| Contents | Read and write | push branches |
+| Pull requests | Read and write | open PRs, submit reviews, comment |
+| Issues | Read and write | edit labels, comment |
+| Checks | Read | reviewer reads check results |
+| Metadata | Read | mandatory baseline |
+
+No webhook, no subscribed events. **Install both apps on the consumer repo**
+after creating them.
+
+### 2. Secrets and variables
+
+On the consumer repo (Settings → Secrets and variables → Actions):
+
+| Kind | Name | Value |
+|---|---|---|
+| Secret | `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token for `anthropics/claude-code-action` |
+| Secret | `CODER_APP_PRIVATE_KEY` | `interns-coder` private key (PEM) |
+| Secret | `REVIEWER_APP_PRIVATE_KEY` | `interns-reviewer` private key (PEM) |
+| Variable | `CODER_APP_ID` | `interns-coder` App ID |
+| Variable | `REVIEWER_APP_ID` | `interns-reviewer` App ID |
+
+Optional variables (per-repo overrides of the pipeline defaults; the
+[`.github/agent-pipeline.yml`](templates/config/agent-pipeline.yml) config file
+wins over these):
+
+| Variable | Default | Effect |
+|---|---|---|
+| `PIPELINE_MODEL` | per-agent built-in | model for every agent |
+| `PIPELINE_MAX_TURNS` | 40 | agent turn ceiling |
+| `PIPELINE_TIMEOUT_MINUTES` | 20 | per-run timeout |
+| `PIPELINE_MAX_OUTPUT_TOKENS` | action default | output-token safety ceiling |
+| `PIPELINE_COST_WARN_USD` | 2.0 | run-summary cost warning threshold |
+| `WIKI_REPO` | unset | `owner/name` of a wiki repo to check out for the agents |
+
+The consumer repo also needs `test` and `build` status checks on its PRs (from
+its own `deploy.yml` or equivalent) — the reviewer waits on them and won't run
+until both are green.
+
+### 3. Default-branch protection
+
+The agents run with the consumer repo's own credentials, so the default branch
+must be protected against every bot identity — `github-actions[bot]`,
+`claude[bot]`, and both apps. The installer's safety check requires, and
+creates when absent (baseline: require a PR, one approval, no force pushes, no
+deletions):
+
+- a required pull-request review;
+- **no** bot identity on the push allowlist.
+
+Opt out with `allow_agent_push_to_default_branch: true` in
+`.github/agent-pipeline.yml` only if protection already blocks the bots some
+other way.
+
+### 4. Run the installer
+
+The supported 0.1.0 path is `interns-install` — a local, interactive CLI that
+does the two things a headless Actions run can't: mint the apps (an interactive
+browser click) and write the repo secrets/variables (`secrets: write` isn't
+grantable to `GITHUB_TOKEN`). It then hands off to `install.yml`.
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/abi83/interns/v0.1.0/install.sh | sh
+```
+
+The bootstrap installs [`uv`](https://docs.astral.sh/uv/) if missing; with `uv`
+already present:
+
+```bash
+uvx --from git+https://github.com/abi83/interns.git@v0.1.0#subdirectory=installer interns-install
+```
+
+Needs the [GitHub CLI](https://cli.github.com/) authenticated (`gh auth login`)
+with a token that can write repo secrets — classic scope `repo`, or a
+fine-grained PAT with **Secrets: write** and **Variables: write** on the target
+repo. Flags and details: [`installer/README.md`](installer/README.md).
+
+`.github/workflows/install.yml` does the rest, and is idempotent:
+
+- syncs the label manifest (re-running fixes label drift);
+- runs the safety checks (§3, plus verifies the secrets/vars exist and enables
+  GitHub Pages) and **refuses to finish if one fails**;
+- opens a PR with the thin caller stubs and a starter `.github/agent-pipeline.yml`,
+  adding only files that are missing — it never overwrites a hand-edited one.
+
+Managing branch protection and reading secrets needs more than `GITHUB_TOKEN`
+carries. Pass a repo-admin token as the `admin_token` secret when calling
+`install.yml`, or set branch protection by hand; without it those checks
+downgrade to a warning but a *definitively* unprotected branch or missing
+secret is still a hard failure.
+
+The fully manual path — create the apps, add the secrets, sync labels, commit
+the stubs yourself — stays supported as the fallback.
+
+### 5. Commit the caller stubs
+
+The installer PR adds two thin callers that own the triggers and delegate to
+the reusable cores, pinned to an exact tag. Merge that PR, or commit them
+yourself:
 
 ```yaml
 # .github/workflows/issue-pipeline.yml
@@ -21,7 +215,9 @@ jobs:
   pipeline:
     uses: abi83/interns/.github/workflows/issue-pipeline.yml@v0.1.0
     secrets: inherit
-    with: { phase: ${{ inputs.phase }} }
+    with:
+      issue_number: ${{ inputs.issue_number }}
+      phase: ${{ inputs.phase }}
 ```
 
 ```yaml
@@ -30,59 +226,63 @@ jobs:
   pipeline:
     uses: abi83/interns/.github/workflows/code-pipeline.yml@v0.1.0
     secrets: inherit
-    with: { phase: ${{ inputs.phase }} }
+    with:
+      issue_number: ${{ inputs.issue_number }}
+      pr_number: ${{ inputs.pr_number }}
+      fix_round: ${{ inputs.fix_round || false }}
+      phase: ${{ inputs.phase }}
 ```
 
-Needs, in the consumer repo: `CLAUDE_CODE_OAUTH_TOKEN` +
-`REVIEWER_APP_PRIVATE_KEY` + `CODER_APP_PRIVATE_KEY` secrets, `REVIEWER_APP_ID`
-and `CODER_APP_ID` vars (the reviewer and coder run as separate GitHub Apps),
-the `status:*` / `type:*` / `size:*` / `priority:*` / `pr:*` labels, and
-default-branch protection.
-Optional: `.github/agent-pipeline.yml` (per-agent model + limits).
+Keep the `@v0.1.0` pin — the reusable cores check out their own matching assets
+from that ref at runtime. Full stubs, including the `on:` triggers, are in
+[`templates/workflows/`](templates/workflows).
 
-### Installer
+Optionally add `.github/agent-pipeline.yml`
+([template](templates/config/agent-pipeline.yml)) for per-agent limits, and the
+default issue templates ([`templates/issue/`](templates/issue)) — pass
+`--issue-templates` to the installer, or `install_issue_templates: true` to
+`install.yml`.
 
-For 0.1.0 the supported path is `interns-install` — a local, interactive CLI
-that does the two things a headless Actions run can't: mint the `interns-reviewer`
-and `interns-coder` GitHub Apps (an interactive browser click) and write the
-repo secrets/variables (`secrets: write` isn't grantable to `GITHUB_TOKEN`). It
-then hands off to `install.yml` for the rest.
+## Troubleshooting
 
-```sh
-curl -LsSf https://raw.githubusercontent.com/abi83/interns/v0.1.0/install.sh | sh
-```
+**A label change didn't start a run.** Label edits made by `GITHUB_TOKEN` (or
+any action using it) don't trigger new workflow runs — GitHub's anti-recursion
+rule. The `status:estimated` → `status:ready` approval must be a **human**
+label edit for the coder to fire. The pipeline works around this internally by
+dispatching the coder fix round with an explicit `workflow_dispatch` instead of
+a label. To re-run a phase by hand, use the `workflow_dispatch` on the caller
+workflow (`phase: refine|estimate` / `phase: coder|reviewer`).
 
-The bootstrap installs [`uv`](https://docs.astral.sh/uv/) if missing; with `uv`
-already present, run
-`uvx --from git+https://github.com/abi83/interns.git@v0.1.0#subdirectory=installer interns-install`.
-Needs the [GitHub CLI](https://cli.github.com/) authenticated with a token that
-can write repo secrets. Details and flags: [`installer/README.md`](installer/README.md).
-The fully manual path stays documented as the fallback.
+**A fork PR got no review.** The reviewer job skips PRs from forks — forked
+runs have no access to secrets, so the app token and OAuth token would be
+empty. Review fork PRs manually. The same skip applies to bot PRs other than
+the coder's `claude[bot]` (Dependabot, etc.).
 
-`.github/workflows/install.yml` provisions a consumer repo. It syncs the
-versioned label manifest ([`.github/labels.json`](.github/labels.json) —
-every `status:*` / `type:*` / `size:*` / `priority:*` / `pr:*` the state
-machine relies on) and opens a PR with the thin caller stubs plus a starter
-`.github/agent-pipeline.yml`. It's idempotent: re-running fixes label drift
-and only adds stub files that are missing, never overwriting a hand-edited
-one. Label sync is additive — labels absent from the manifest are left
-alone.
+**The installer's safety check failed.**
 
-Before opening the PR it runs safety checks and refuses to finish if one
-fails: the default branch must be protected so the agent identities can't
-push to it (it applies a baseline — require a PR, one approval, no force
-pushes — when protection is absent, unless
-`allow_agent_push_to_default_branch: true` in the config opts out); the
-`CLAUDE_CODE_OAUTH_TOKEN`, `REVIEWER_APP_PRIVATE_KEY` and
-`CODER_APP_PRIVATE_KEY` secrets and the `REVIEWER_APP_ID` / `CODER_APP_ID`
-variables must exist; and Pages is enabled (switched on with the GitHub Actions
-build type when off). Managing branch protection and Pages needs a token with
-`administration` scope; reading secrets and variables needs more than
-`GITHUB_TOKEN` carries, so those checks downgrade to a warning when they can't
-list them.
+| Failure | Fix |
+|---|---|
+| `missing repo secret(s)` / `variable(s)` | add them (§2) — the installer can't set their values |
+| `can't read branch protection … needs repo-admin scope` | pass an admin token as `install.yml`'s `admin_token` secret, or set protection by hand (§3) |
+| `branch '…' push allowlist grants '…[bot]'` | remove that bot from the default branch's push restrictions |
+| `GitHub Pages could not be enabled` | turn it on under Settings → Pages (build type: GitHub Actions) |
 
-A fuller README — pipeline flow, label state table — is
-[#10](https://github.com/abi83/interns/issues/10).
+**An issue on `status:ready` bounced to `status:needs-attention`.** It reached
+the coder without a `type:coding-task` or `type:bug` label — only those two are
+implementable. Add the right type label and re-apply `status:ready`.
+
+**A PR is stuck on `pr:needs-attention`.** One of: the `test` / `build` checks
+went red (the coder is expected to push green — this goes straight to a human,
+no retry), a second review round still requested changes (the fix loop didn't
+converge), or the automatic-review cap (5 per PR) was hit. Read the PR comment
+the pipeline left for which. Re-engage a reviewer with the caller's
+`workflow_dispatch` (`phase: reviewer`, `pr_number: N`) once addressed.
+
+**The coder declined a fix round.** It left a comment on the issue explaining
+why (feedback needs a protected path, is out of scope, or needs an owner
+decision) and set `status:needs-attention`. Pipeline config under
+`.github/workflows/` and the `gh-safe` / `pipeline` scripts are protected —
+`push-branch.sh` rejects any push touching them.
 
 ## Pipeline metrics
 


### PR DESCRIPTION
Rewrites the README into a complete consumer-facing setup and operations guide, per #10.

## What changed

- **What it does** — the four agents (refiner / estimator / coder / reviewer) as a table, plus a Mermaid diagram of the refine → estimate → code → review flow including escalation edges.
- **Label state machine** — every `status:*` / `pr:*` / `type:*` / `size:*` / `priority:*`, who sets each, and the transitions the pipeline drives. Calls out the human approval gate (`status:estimated` → `status:ready`) and that an approved PR carries no `pr:*` label.
- **Setup** — 5 numbered steps: register the two GitHub Apps with the permission matrix (contents RW, pull requests RW, issues RW, checks read, metadata read) + install-on-repo; required secrets/vars (and optional `PIPELINE_*` / `WIKI_REPO`, plus the `test` / `build` check requirement); default-branch protection expectations and the `allow_agent_push_to_default_branch` opt-out; run the `interns-install` → `install.yml` installer; commit the `@v0.1.0`-pinned caller stubs.
- **Troubleshooting** — `GITHUB_TOKEN` label edits not firing runs, fork/bot PRs the reviewer skips, each installer safety-check failure and its fix, the `type` gate bounce, `pr:needs-attention` causes, and coder fix-round decline / protected paths.
- Removed the "a fuller README is #10" pointer. Metrics and Layout sections retained (Layout unchanged).

Docs only — no code or workflow changes.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)