### PR TITLE
chore: drop the unused status:estimated-wrong label

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,11 +1,10 @@
 {
   "$schema": "./labels.schema.json",
-  "version": 1,
+  "version": 2,
   "labels": [
     { "name": "status:needs-refinement", "color": "1d76db", "description": "Issue pipeline: awaiting the refiner agent" },
     { "name": "status:refined", "color": "1d76db", "description": "Issue pipeline: refined, awaiting estimation" },
     { "name": "status:estimated", "color": "1d76db", "description": "Issue pipeline: estimated, awaiting owner approval" },
-    { "name": "status:estimated-wrong", "color": "d93f0b", "description": "Issue pipeline: estimate rejected by the owner" },
     { "name": "status:ready", "color": "0e8a16", "description": "Approved for the coder agent to implement" },
     { "name": "status:in-progress", "color": "fbca04", "description": "A coder agent run is working this issue" },
     { "name": "status:needs-attention", "color": "b60205", "description": "Pipeline stalled — a human needs to look" },

--- a/.github/scripts/pipeline/tests/verify-outcome.bats
+++ b/.github/scripts/pipeline/tests/verify-outcome.bats
@@ -18,7 +18,7 @@ setup() {
 }
 
 @test "three expected labels use an Oxford comma" {
-  export STUB_ISSUE_LABELS="status:estimated-wrong"
+  export STUB_ISSUE_LABELS="status:refined"
   run "$PIPELINE_DIR/verify-outcome.sh" Estimation 3 status:estimated status:ready status:needs-attention
   grep -q '`status:estimated`, `status:ready`, or `status:needs-attention`' "$STUB_LOG"
 }

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ flowchart TD
     refined -.->|epic| ready
     refined -.->|needs a decision| na
     est -->|owner approves| ready[status:ready]
-    est -->|owner rejects| wrong[status:estimated-wrong]
-    wrong -.->|owner re-triggers| refined
+    est -.->|owner rejects, re-triggers| refined
     ready -->|coder| inprog[status:in-progress]
     inprog -->|PR opened| review[PR: pr:in-review]
     review -->|reviewer: APPROVE| merge([owner merges → issue closed])
@@ -58,8 +57,7 @@ not in the manifest are left alone.
 |---|---|---|---|
 | `status:needs-refinement` | awaiting the refiner | human, on issue creation | `status:refined`, or `status:needs-attention` if the refiner needs a decision |
 | `status:refined` | refined, awaiting estimation | refiner | `status:estimated` (+ `size:*`); `status:ready` directly for a `type:epic`; `status:needs-attention` if unsizeable |
-| `status:estimated` | estimated, awaiting owner approval | estimator | `status:ready` (owner approves) or `status:estimated-wrong` (owner rejects) |
-| `status:estimated-wrong` | estimate rejected by the owner | human | owner edits the issue and re-triggers refinement/estimation |
+| `status:estimated` | estimated, awaiting owner approval | estimator | `status:ready` (owner approves); if the owner disagrees they edit the issue and re-trigger refinement/estimation |
 | `status:ready` | approved for the coder | **human** (this is the approval gate) | `status:in-progress` when the coder starts; `status:needs-attention` if the issue isn't a `type:coding-task` / `type:bug` |
 | `status:in-progress` | a coder run is working the issue (held for the whole run, fix rounds included) | coder | issue closed on merge, or `status:needs-attention` |
 | `status:needs-attention` | pipeline stalled — a human needs to look | any agent | cleared when a human re-dispatches (the coder drops it on pickup) |


### PR DESCRIPTION
## What

Removes `status:estimated-wrong` — a label that was declared in the manifest but never wired to any behaviour.

- No workflow triggers on it and no agent sets it. The estimator only does the approve-path handoff (`status:refined` → `status:estimated`); "owner rejects" was a documented hypothetical.
- A rejected estimate is already handled: the owner edits the issue and re-triggers refinement/estimation, or the generic `status:needs-attention` park state applies.

## Changes

- `.github/labels.json` — drop the entry; bump `version` 1 → 2 (schema requires a bump on any label-set change).
- `README.md` — remove the `status:estimated-wrong` node/row from the mermaid flow and the `status:*` state table; fold the reject path into the `status:estimated` row.
- `.github/scripts/pipeline/tests/verify-outcome.bats` — the "Oxford comma" test borrowed this label as an arbitrary off-list example; swapped for `status:refined`. `bats` suite passes.

## Note for consumers

Label sync is additive, so this does **not** delete the label from repos that already have it. To finish the cleanup, run `gh label delete "status:estimated-wrong"` in this repo and in `abi83/prepify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)