### PR TITLE
Add install.yml wrapper so first-time install can hand off

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ repo** (needed to create repo secrets and variables):
 curl -LsSf https://raw.githubusercontent.com/abi83/interns/v0.1.0/install.sh | sh
 ```
 
-That's it. The script installs [`uv`](https://docs.astral.sh/uv/) if it's missing,
-then runs the `interns-install` CLI.
+The script installs [`uv`](https://docs.astral.sh/uv/) if it's missing, then
+runs the `interns-install` CLI. On a fresh repo you merge two small PRs it
+opens (the install wrapper, then the caller stubs) and re-run it once in
+between — see the steps below.
 
 ### What the installer does
 
@@ -148,8 +150,9 @@ re-run either any time to fix drift.
 | 2 | Check (and enable) GitHub Pages | Deploy target for the visibility dashboard ([#6](https://github.com/abi83/interns/issues/6)). |
 | 3 | Mint the two GitHub Apps | Separate coder/reviewer identities, so the reviewer can approve the coder's PRs (`claude[bot]` can't approve its own). |
 | 4 | Write App secrets/variables + `CLAUDE_CODE_OAUTH_TOKEN` | The workflows need these to authenticate as the Apps and call Claude. |
-| 5 | Sync labels | The pipeline routes on `status:*` / `type:*` / `pr:*` and can't run without them. |
-| 6 | Open the caller-stub PR | Adds the pipeline's workflows and starter config; merging it finishes setup. |
+| 5 | Hand off to `install.yml` | If no caller for it exists yet, open a one-file PR adding `.github/workflows/install.yml` (a thin wrapper) — merge it and re-run the installer. Once present, dispatch it. |
+| 6 | (`install.yml`) Sync labels | The pipeline routes on `status:*` / `type:*` / `pr:*` and can't run without them. |
+| 7 | (`install.yml`) Open the caller-stub PR | Adds the pipeline's workflows and starter config; merging it finishes setup. |
 
 #### Default-branch protection
 
@@ -202,6 +205,16 @@ The `install.yml` safety check fails the install if a required secret or
 variable is missing; if its token can't list them it warns and leaves
 verification to you.
 
+#### Install wrapper
+
+`install.yml` is a reusable workflow in `abi83/interns`; a consumer repo can
+only invoke it through a local caller. When `interns-install` finds none, it
+opens a one-file PR adding
+[`.github/workflows/install.yml`](templates/workflows/install.yml) — a thin
+`workflow_dispatch` wrapper pinned to `@v0.1.0`. Merge it (branch protection is
+already on, so it can't be a direct push), then re-run `interns-install`; it
+dispatches the wrapper and proceeds to the caller-stub PR.
+
 #### Caller-stub PR
 
 Adds two thin caller workflows that own the triggers and delegate to the
@@ -232,9 +245,12 @@ until both are green.
 <summary>The manual path, without <code>interns-install</code></summary>
 
 The fully manual path stays supported: create the two Apps with the permissions
-above and install them on the repo, add the secrets and variables, sync labels
-from the manifest, set branch protection, and commit the caller stubs from
-[`templates/workflows/`](templates/workflows) yourself.
+above and install them on the repo, add the secrets and variables, set branch
+protection, and commit the caller stubs from
+[`templates/workflows/`](templates/workflows) yourself — including
+[`install.yml`](templates/workflows/install.yml). With that wrapper in place,
+run it (`gh workflow run install.yml`) to sync labels and open the caller-stub
+PR, or sync labels from the manifest by hand.
 
 </details>
 

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,8 @@
 
 set -eu
 
-INTERNS_REF="${INTERNS_REF:-v0.1.0}"
+# Exported so interns-install copies the install wrapper from the same ref.
+export INTERNS_REF="${INTERNS_REF:-v0.1.0}"
 SPEC="git+https://github.com/abi83/interns.git@${INTERNS_REF}#subdirectory=installer"
 
 if ! command -v uv >/dev/null 2>&1; then

--- a/installer/README.md
+++ b/installer/README.md
@@ -5,6 +5,11 @@ repo secrets and variables, checks default-branch protection and Pages, then
 hands off to `install.yml`. It runs locally because `GITHUB_TOKEN` is never
 granted admin access or `secrets: write`.
 
+`install.yml` is a reusable workflow in `abi83/interns`, so the handoff needs a
+local caller. If the repo has none, the CLI opens a one-file PR adding
+`.github/workflows/install.yml` (the wrapper from `templates/workflows/`);
+merge it and re-run the CLI, which then dispatches it.
+
 What it does, step by step, and how it fits the rest of setup:
 [the root README](../README.md).
 

--- a/installer/src/interns_install/cli.py
+++ b/installer/src/interns_install/cli.py
@@ -13,7 +13,9 @@ handed off to `install.yml`.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
+import time
 import webbrowser
 
 from . import gh, safety
@@ -21,6 +23,22 @@ from .apps import APPS, AppSpec, ManifestServer, build_manifest, settings_new_ur
 from .console import Console
 
 WORKFLOW = "install.yml"
+INTERNS_REPO = "abi83/interns"
+
+# Ref to copy the install wrapper from. install.sh exports INTERNS_REF; the
+# default matches the pin baked into the templates.
+INTERNS_REF = os.environ.get("INTERNS_REF") or "v0.1.0"
+
+WRAPPER_PR_BODY = """\
+## Add the interns install workflow
+
+`install.yml` can only be dispatched once a thin caller for it exists in this
+repo — `interns-install` opened this PR to add it.
+
+After merging, re-run `interns-install` (or dispatch **Install interns** from
+the Actions tab). That run syncs the label manifest and opens the caller-stub
+PR that finishes setup.
+"""
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -133,12 +151,7 @@ def _handoff(con: Console, repo: gh.Repo, args: argparse.Namespace) -> None:
     inputs = {"install_issue_templates": args.issue_templates}
 
     if not gh.workflow_exists(repo.slug, WORKFLOW):
-        con.note_manual(
-            f"add a thin wrapper that calls abi83/interns/.github/workflows/{WORKFLOW} "
-            f"(see the interns README), then run it — or `gh workflow run {WORKFLOW} "
-            f"--repo {repo.slug}` once present"
-        )
-        con.say(f"{WORKFLOW} is not in {repo.slug} yet — see the summary for the manual step")
+        _add_wrapper(con, repo)
         return
 
     ref = args.handoff_ref or _default_branch(repo)
@@ -147,6 +160,36 @@ def _handoff(con: Console, repo: gh.Repo, args: argparse.Namespace) -> None:
         return
     if con.mutation(f"dispatch {WORKFLOW} on {repo.slug}@{ref}"):
         gh.dispatch_workflow(repo.slug, WORKFLOW, ref, inputs)
+
+
+def _add_wrapper(con: Console, repo: gh.Repo) -> None:
+    con.say(f"{WORKFLOW} is not in {repo.slug} yet — it needs a thin caller wrapper "
+            "before it can run")
+    if not con.confirm(f"Open a PR adding .github/workflows/{WORKFLOW}?", default=True):
+        con.note_manual(
+            f"copy templates/workflows/{WORKFLOW} from {INTERNS_REPO} to "
+            f".github/workflows/{WORKFLOW}, merge it, then re-run interns-install"
+        )
+        return
+
+    if not con.mutation(f"open a PR adding .github/workflows/{WORKFLOW} to {repo.slug}"):
+        con.note_manual(f"merge the {WORKFLOW} wrapper PR, then re-run interns-install")
+        return
+
+    wrapper = gh.get_file(INTERNS_REPO, f"templates/workflows/{WORKFLOW}", INTERNS_REF)
+    base = _default_branch(repo)
+    branch = f"interns/install-wrapper-{int(time.time())}"
+    sha = gh.branch_head_sha(repo.slug, base)
+    gh.create_branch(repo.slug, branch, sha)
+    gh.put_file(repo.slug, f".github/workflows/{WORKFLOW}", wrapper,
+                "chore: add interns install workflow wrapper", branch)
+    url = gh.create_pr(repo.slug, branch, base,
+                       "Add the interns install workflow", WRAPPER_PR_BODY)
+    con.say(f"opened {url}")
+    con.note_manual(
+        f"merge {url}, then re-run interns-install (or `gh workflow run {WORKFLOW} "
+        f"--repo {repo.slug}`) to sync labels and open the caller-stub PR"
+    )
 
 
 def _default_branch(repo: gh.Repo) -> str:

--- a/installer/src/interns_install/gh.py
+++ b/installer/src/interns_install/gh.py
@@ -6,6 +6,7 @@ operator's own credentials — never a token written to disk.
 
 from __future__ import annotations
 
+import base64
 import json
 import shutil
 import subprocess
@@ -145,3 +146,38 @@ def dispatch_workflow(repo: str, workflow: str, ref: str, inputs: dict[str, str]
     for key, value in inputs.items():
         args += ["-f", f"{key}={value}"]
     _run(args)
+
+
+def get_file(repo: str, path: str, ref: str) -> str:
+    """Text content of `path` in `repo` at `ref`, via the contents API."""
+    data = api(f"repos/{repo}/contents/{path}?ref={ref}")
+    if not isinstance(data, dict) or "content" not in data:
+        raise GhError(f"could not read {path} from {repo}@{ref}")
+    return base64.b64decode(data["content"]).decode()
+
+
+def branch_head_sha(repo: str, branch: str) -> str:
+    data = api(f"repos/{repo}/git/ref/heads/{branch}")
+    if not isinstance(data, dict):
+        raise GhError(f"could not resolve heads/{branch} on {repo}")
+    return data["object"]["sha"]
+
+
+def create_branch(repo: str, branch: str, sha: str) -> None:
+    api(f"repos/{repo}/git/refs", method="POST",
+        fields={"ref": f"refs/heads/{branch}", "sha": sha})
+
+
+def put_file(repo: str, path: str, content: str, message: str, branch: str) -> None:
+    api(f"repos/{repo}/contents/{path}", method="PUT", fields={
+        "message": message,
+        "content": base64.b64encode(content.encode()).decode(),
+        "branch": branch,
+    })
+
+
+def create_pr(repo: str, head: str, base: str, title: str, body: str) -> str:
+    """Open a PR and return its URL."""
+    proc = _run(["pr", "create", "--repo", repo, "--head", head, "--base", base,
+                 "--title", title, "--body", body])
+    return proc.stdout.strip()

--- a/installer/tests/test_cli.py
+++ b/installer/tests/test_cli.py
@@ -1,7 +1,9 @@
 import unittest
+from unittest import mock
 
-from interns_install import gh
-from interns_install.cli import _parse_args, _secret_verb
+from interns_install import cli, gh
+from interns_install.cli import _add_wrapper, _parse_args, _secret_verb
+from interns_install.console import Console
 
 
 class ArgTests(unittest.TestCase):
@@ -38,6 +40,36 @@ class ScopeParseTests(unittest.TestCase):
 
     def test_no_scopes_line(self):
         self.assertEqual(gh._parse_scopes("Logged in to github.com"), set())
+
+
+class AddWrapperTests(unittest.TestCase):
+    def _repo(self):
+        return gh.Repo(owner="acme", name="widgets", is_org=False)
+
+    def test_opens_pr_and_records_manual_followup(self):
+        con = Console(assume_yes=True)
+        with mock.patch.multiple(
+            cli.gh,
+            get_file=mock.DEFAULT, branch_head_sha=mock.DEFAULT,
+            create_branch=mock.DEFAULT, put_file=mock.DEFAULT, create_pr=mock.DEFAULT,
+        ) as m:
+            m["get_file"].return_value = "name: Install interns\n"
+            m["branch_head_sha"].return_value = "abc123"
+            m["create_pr"].return_value = "https://github.com/acme/widgets/pull/7"
+            with mock.patch.object(cli, "_default_branch", return_value="main"):
+                _add_wrapper(con, self._repo())
+
+        m["get_file"].assert_called_once_with(
+            cli.INTERNS_REPO, "templates/workflows/install.yml", cli.INTERNS_REF)
+        m["put_file"].assert_called_once()
+        self.assertTrue(any("pull/7" in note for note in con.manual))
+
+    def test_dry_run_makes_no_calls(self):
+        con = Console(assume_yes=True, dry_run=True)
+        with mock.patch.object(cli.gh, "get_file") as get_file:
+            _add_wrapper(con, self._repo())
+        get_file.assert_not_called()
+        self.assertTrue(con.manual)
 
 
 if __name__ == "__main__":

--- a/templates/workflows/install.yml
+++ b/templates/workflows/install.yml
@@ -1,0 +1,38 @@
+# Thin caller for the interns install workflow.
+# interns-install opens the PR that adds this file, then dispatches it once the
+# PR is merged. Re-run any time from the Actions tab: label drift re-syncs and
+# caller stubs already present are skipped.
+name: Install interns
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "interns ref for the manifest/templates (blank = the pinned tag)"
+        required: false
+        type: string
+        default: ""
+      open_pr:
+        description: Open the caller-stubs PR (uncheck for label sync only)
+        required: false
+        type: boolean
+        default: true
+      install_issue_templates:
+        description: Add the default issue templates if the repo has none
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  install:
+    uses: abi83/interns/.github/workflows/install.yml@v0.1.0
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+      open_pr: ${{ inputs.open_pr }}
+      install_issue_templates: ${{ inputs.install_issue_templates }}


### PR DESCRIPTION
Closes #45.

## Problem

On a genuine first-time install there was no way for `interns-install` to hand
off to `install.yml`: it's a reusable workflow in this repo, a consumer repo
can only invoke it through a local caller, and nothing created one. The single
script that stages caller stubs (`stage-stubs.sh`) runs *inside* `install.yml`,
so it couldn't bootstrap itself.

## Change

Fix option 1 from the issue:

- **`templates/workflows/install.yml`** — a thin `workflow_dispatch` wrapper
  (`uses: abi83/interns/.github/workflows/install.yml@v0.1.0`), same shape as
  the other caller-stub templates.
- **`interns-install`** — the handoff step now checks for a local caller. If
  none exists, it opens a one-file PR adding `.github/workflows/install.yml`
  (branch protection is already enabled by this point, so it can't be a direct
  push), and notes that the operator should merge it and re-run. Once the
  wrapper is present, the handoff dispatches it as before. Dry-run makes no
  API calls.
- **`install.sh`** exports `INTERNS_REF` so the CLI copies the wrapper from the
  same ref the installer was launched at.
- **`gh.py`** — small helpers: `get_file`, `branch_head_sha`, `create_branch`,
  `put_file`, `create_pr`.
- **README + `installer/README.md`** — document the wrapper step, adjust the
  "What the installer does" table, update the "Doing it by hand" path, and drop
  the "That's it." framing.

## Tests

`PYTHONPATH=src python -m unittest discover -s tests` — 17 pass. New cases cover
`_add_wrapper` opening the PR / recording the manual follow-up, and dry-run
making no calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
