### PR TITLE
fix(pipeline): gate the reviewer on all PR checks, not just test/build

### DIFF
--- a/.github/interns.schema.json
+++ b/.github/interns.schema.json
@@ -27,6 +27,17 @@
           "description": "owner/name of a wiki repo to check out for the agents. Required when enabled is true."
         }
       }
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ignore": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Check names the reviewer gate ignores — for non-blocking advisory checks (preview deploys, coverage deltas). Everything else must be green before the reviewer runs."
+        }
+      }
     }
   },
   "definitions": {

--- a/.github/scripts/pipeline/agent-config.sh
+++ b/.github/scripts/pipeline/agent-config.sh
@@ -53,7 +53,9 @@ if [[ -f "$config" ]]; then
   while IFS= read -r k; do
     [[ -z "$k" ]] && continue
     case "$k" in
-      defaults | agents | wiki) ;;
+      # `checks` (the reviewer's ignore list) is consumed by wait-for-checks.sh,
+      # not here — accept it so a valid config doesn't trip the unknown-key gate.
+      defaults | agents | wiki | checks) ;;
       *) die "unknown top-level key '$k' in $config" ;;
     esac
   done < <(yq 'keys | .[]' "$config")

--- a/.github/scripts/pipeline/route-red-checks.sh
+++ b/.github/scripts/pipeline/route-red-checks.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# The `test` / `build` checks aren't green, so the reviewer won't run. The
-# coder writes and runs tests before pushing, so a red check here goes straight
-# to a human rather than back through a coder retry (#133).
+# A PR check isn't green, so the reviewer won't run. The coder writes and runs
+# tests before pushing, so a red check here goes straight to a human rather
+# than back through a coder retry (#133).
 #
 # Usage: route-red-checks.sh <pr> <issue-or-empty> <reason>
 
@@ -16,7 +16,7 @@ reason="$3"
 
 escalate_pr "$pr"
 gh pr comment "$pr" --repo "$GITHUB_REPOSITORY" --body \
-  "Required checks are not green ($reason) — the reviewer won't run. The coder writes and runs tests before pushing, so this is being sent straight to a human rather than retried. Run: $(run_url)"
+  "PR checks are not green ($reason) — the reviewer won't run. The coder writes and runs tests before pushing, so this is being sent straight to a human rather than retried. Run: $(run_url)"
 if [[ -n "$issue" ]]; then
   set_issue_status "$issue" status:needs-attention
 fi

--- a/.github/scripts/pipeline/route-red-checks.sh
+++ b/.github/scripts/pipeline/route-red-checks.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 #
-# A PR check isn't green, so the reviewer won't run. The coder writes and runs
-# tests before pushing, so a red check here goes straight to a human rather
-# than back through a coder retry (#133).
+# A red PR check goes straight to a human, no coder retry loop (#133).
 #
 # Usage: route-red-checks.sh <pr> <issue-or-empty> <reason>
 

--- a/.github/scripts/pipeline/tests/route-red-checks.bats
+++ b/.github/scripts/pipeline/tests/route-red-checks.bats
@@ -5,10 +5,10 @@ setup() {
 
 @test "marks the PR pr:needs-attention, comments, and flags the linked issue" {
   export STUB_PR_LABELS="pr:in-review" STUB_ISSUE_LABELS="status:in-progress"
-  run "$PIPELINE_DIR/route-red-checks.sh" 8 19 '`test`=fail, `build`=pass'
+  run "$PIPELINE_DIR/route-red-checks.sh" 8 19 'red checks: lint=fail'
   [ "$status" -eq 0 ]
   grep -q 'gh pr edit 8 --repo owner/repo --remove-label pr:in-review --add-label pr:needs-attention' "$STUB_LOG"
-  grep -q 'gh pr comment 8 .* Required checks are not green (`test`=fail, `build`=pass)' "$STUB_LOG"
+  grep -q 'gh pr comment 8 .* PR checks are not green (red checks: lint=fail)' "$STUB_LOG"
   grep -q 'gh issue edit 19 --repo owner/repo --add-label status:needs-attention --remove-label status:in-progress' "$STUB_LOG"
 }
 

--- a/.github/scripts/pipeline/tests/wait-for-checks.bats
+++ b/.github/scripts/pipeline/tests/wait-for-checks.bats
@@ -1,7 +1,12 @@
 setup() {
   load helpers
   setup_stubs
+  export CHECK_POLL_SECONDS=0
+  export CHECK_SETTLE_SECONDS=0
 }
+
+# A check that belongs to some other workflow run.
+chk() { printf '{"name":"%s","bucket":"%s","link":"https://github.com/owner/repo/actions/runs/99/job/1"}' "$1" "$2"; }
 
 @test "workflow_dispatch skips the gate" {
   export GITHUB_EVENT_NAME=workflow_dispatch
@@ -10,26 +15,79 @@ setup() {
   grep -qx 'ok=true' "$GITHUB_OUTPUT"
 }
 
-@test "both checks passing -> ok=true" {
-  export STUB_PR_CHECKS='[{"name":"test","bucket":"pass"},{"name":"build","bucket":"pass"}]'
+@test "every check green -> ok=true" {
+  export STUB_PR_CHECKS="[$(chk test pass),$(chk build pass),$(chk lint pass),$(chk coverage skipping)]"
   run "$PIPELINE_DIR/wait-for-checks.sh" 5
   [ "$status" -eq 0 ]
   grep -qx 'ok=true' "$GITHUB_OUTPUT"
 }
 
-@test "a failing check -> ok=false with a reason" {
-  export STUB_PR_CHECKS='[{"name":"test","bucket":"fail"},{"name":"build","bucket":"pass"}]'
+@test "one red among several green -> ok=false with a reason naming it" {
+  export STUB_PR_CHECKS="[$(chk test pass),$(chk build pass),$(chk lint fail),$(chk typecheck pass)]"
   run "$PIPELINE_DIR/wait-for-checks.sh" 5
   [ "$status" -eq 0 ]
   grep -qx 'ok=false' "$GITHUB_OUTPUT"
-  grep -qx 'reason=`test`=fail, `build`=pass' "$GITHUB_OUTPUT"
+  grep -q 'reason=red checks: lint=fail' "$GITHUB_OUTPUT"
+}
+
+@test "a cancelled check counts as red" {
+  export STUB_PR_CHECKS="[$(chk test pass),$(chk build cancel)]"
+  run "$PIPELINE_DIR/wait-for-checks.sh" 5
+  grep -qx 'ok=false' "$GITHUB_OUTPUT"
+  grep -q 'build=cancel' "$GITHUB_OUTPUT"
+}
+
+@test "a pending check that later passes -> ok=true" {
+  cat >"$BATS_TEST_TMPDIR/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+n="$BATS_TEST_TMPDIR/n"; c=$(( $(cat "$n" 2>/dev/null || echo 0) + 1 )); echo "$c" >"$n"
+if [ "$c" -lt 2 ]; then
+  echo '[{"name":"test","bucket":"pending","link":"https://github.com/owner/repo/actions/runs/99/job/1"}]'
+else
+  echo '[{"name":"test","bucket":"pass","link":"https://github.com/owner/repo/actions/runs/99/job/1"}]'
+fi
+EOF
+  chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+  run "$PIPELINE_DIR/wait-for-checks.sh" 5
+  [ "$status" -eq 0 ]
+  grep -qx 'ok=true' "$GITHUB_OUTPUT"
+}
+
+@test "the reviewer's own run is excluded from the set it waits on" {
+  # Only check present belongs to this run ($GITHUB_RUN_ID=42) and is pending;
+  # with a zero settle window that must resolve to "no checks -> ok=true", not
+  # a timeout.
+  export STUB_PR_CHECKS='[{"name":"pipeline / reviewer","bucket":"pending","link":"https://github.com/owner/repo/actions/runs/42/job/7"}]'
+  run "$PIPELINE_DIR/wait-for-checks.sh" 5
+  [ "$status" -eq 0 ]
+  grep -qx 'ok=true' "$GITHUB_OUTPUT"
+}
+
+@test "checks.ignore in the config drops an advisory check" {
+  export INTERNS_CONFIG="$BATS_TEST_TMPDIR/interns.yml"
+  cat >"$INTERNS_CONFIG" <<'EOF'
+checks:
+  ignore:
+    - preview-deploy
+EOF
+  export STUB_PR_CHECKS="[$(chk test pass),$(chk preview-deploy fail)]"
+  run "$PIPELINE_DIR/wait-for-checks.sh" 5
+  [ "$status" -eq 0 ]
+  grep -qx 'ok=true' "$GITHUB_OUTPUT"
 }
 
 @test "times out when a check never resolves" {
-  export STUB_PR_CHECKS='[{"name":"test","bucket":"pending"},{"name":"build","bucket":"pending"}]'
+  export STUB_PR_CHECKS="[$(chk test pending),$(chk build pass)]"
   export CHECK_TIMEOUT_SECONDS=0
   run "$PIPELINE_DIR/wait-for-checks.sh" 5
   [ "$status" -eq 0 ]
   grep -qx 'ok=false' "$GITHUB_OUTPUT"
-  grep -q 'reason=timed out' "$GITHUB_OUTPUT"
+  grep -q 'reason=timed out waiting for checks to finish: test' "$GITHUB_OUTPUT"
+}
+
+@test "no checks at all -> ok=true after the settle window" {
+  export STUB_PR_CHECKS='[]'
+  run "$PIPELINE_DIR/wait-for-checks.sh" 5
+  [ "$status" -eq 0 ]
+  grep -qx 'ok=true' "$GITHUB_OUTPUT"
 }

--- a/.github/scripts/pipeline/wait-for-checks.sh
+++ b/.github/scripts/pipeline/wait-for-checks.sh
@@ -1,24 +1,15 @@
 #!/usr/bin/env bash
 #
-# Reviewer gate. Waits for every check on the PR to finish, then writes `ok`
-# (and `reason` when not ok) to $GITHUB_OUTPUT:
+# Reviewer gate: block until every check on the PR has finished, then write
+# `ok` (and `reason` when not ok) to $GITHUB_OUTPUT. A red check routes the PR
+# to a human with no coder retry (#133); workflow_dispatch skips the gate.
 #
-#   - any check red (fail / cancel)              -> ok=false, route to a human (#133)
-#   - every check green (pass, or skipping)      -> ok=true, the reviewer runs
-#   - anything still pending                     -> keep polling to the timeout,
-#                                                   then ok=false ("timed out")
-#
-# The reviewer's own run is excluded from the set it waits on (its checks carry
-# this run's id in their link), otherwise it would wait on itself forever.
-# Checks named in `checks.ignore` in .github/interns.yml are excluded too, for
-# repos that run non-blocking advisory checks (preview deploys, coverage deltas).
-#
-# A manual workflow_dispatch review is an explicit override and skips the gate.
+# Two things are excluded from the wait: this workflow run's own checks (they
+# never finish before the gate does) and anything in `checks.ignore` in
+# .github/interns.yml (non-blocking advisory checks).
 #
 # Usage: wait-for-checks.sh <pr-number>
-#   Env knobs (defaults match CI): CHECK_TIMEOUT_SECONDS=1200,
-#   CHECK_POLL_SECONDS=20, CHECK_SETTLE_SECONDS=30 (grace for checks to register
-#   on a PR that reports none yet).
+#   Env: CHECK_TIMEOUT_SECONDS=1200, CHECK_POLL_SECONDS=20, CHECK_SETTLE_SECONDS=30
 
 set -euo pipefail
 
@@ -44,10 +35,8 @@ if [[ -f "$CONFIG" ]]; then
   jq -e 'type == "array"' <<<"$IGNORE" >/dev/null 2>&1 || IGNORE='[]'
 fi
 
-# Reduce the PR's checks to the ones this gate cares about (not our own run,
-# not explicitly ignored) and classify them: `.red` is "name=bucket" for every
-# failed/cancelled check, `.pending` is the names still running, `.total` is
-# how many checks were considered.
+# checks JSON -> {total, red: ["name=bucket"...], pending: ["name"...]},
+# dropping this run's own checks and any ignored by name.
 classify() {
   jq -c --arg run "$RUN_ID" --argjson ignore "$IGNORE" '
     [ .[]
@@ -77,6 +66,7 @@ while :; do
     emit "reason=red checks: $red"
     exit 0
   fi
+  # No checks yet: wait out the settle window in case CI is still registering.
   if [[ "$total" -eq 0 && "$SECONDS" -ge "$SETTLE" ]]; then
     echo "No checks reported on this PR — nothing to wait on."
     emit "ok=true"

--- a/.github/scripts/pipeline/wait-for-checks.sh
+++ b/.github/scripts/pipeline/wait-for-checks.sh
@@ -1,13 +1,24 @@
 #!/usr/bin/env bash
 #
-# Reviewer gate. The `test` and `build` checks (deploy.yml) are the single
-# source of truth for "is it green" — the reviewer no longer runs them itself
-# (#134). Waits for both to finish, then writes `ok` (and `reason` when not ok)
-# to $GITHUB_OUTPUT. A red check routes to a human, no coder retry loop (#133).
+# Reviewer gate. Waits for every check on the PR to finish, then writes `ok`
+# (and `reason` when not ok) to $GITHUB_OUTPUT:
+#
+#   - any check red (fail / cancel)              -> ok=false, route to a human (#133)
+#   - every check green (pass, or skipping)      -> ok=true, the reviewer runs
+#   - anything still pending                     -> keep polling to the timeout,
+#                                                   then ok=false ("timed out")
+#
+# The reviewer's own run is excluded from the set it waits on (its checks carry
+# this run's id in their link), otherwise it would wait on itself forever.
+# Checks named in `checks.ignore` in .github/interns.yml are excluded too, for
+# repos that run non-blocking advisory checks (preview deploys, coverage deltas).
+#
 # A manual workflow_dispatch review is an explicit override and skips the gate.
 #
 # Usage: wait-for-checks.sh <pr-number>
-#   Env knobs (defaults match CI): CHECK_TIMEOUT_SECONDS=1200, CHECK_POLL_SECONDS=20
+#   Env knobs (defaults match CI): CHECK_TIMEOUT_SECONDS=1200,
+#   CHECK_POLL_SECONDS=20, CHECK_SETTLE_SECONDS=30 (grace for checks to register
+#   on a PR that reports none yet).
 
 set -euo pipefail
 
@@ -15,29 +26,70 @@ PR="$1"
 REPO="$GITHUB_REPOSITORY"
 TIMEOUT="${CHECK_TIMEOUT_SECONDS:-1200}"
 POLL="${CHECK_POLL_SECONDS:-20}"
+SETTLE="${CHECK_SETTLE_SECONDS:-30}"
+RUN_ID="${GITHUB_RUN_ID:-}"
+CONFIG="${INTERNS_CONFIG:-.github/interns.yml}"
 
-if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+emit() { echo "$1" >> "$GITHUB_OUTPUT"; }
+
+if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
   echo "Manual dispatch — skipping the check gate."
-  echo "ok=true" >> "$GITHUB_OUTPUT"
+  emit "ok=true"
   exit 0
 fi
 
+IGNORE='[]'
+if [[ -f "$CONFIG" ]]; then
+  IGNORE=$(yq -o=json -I=0 '.checks.ignore // []' "$CONFIG" 2>/dev/null || echo '[]')
+  jq -e 'type == "array"' <<<"$IGNORE" >/dev/null 2>&1 || IGNORE='[]'
+fi
+
+# Reduce the PR's checks to the ones this gate cares about (not our own run,
+# not explicitly ignored) and classify them: `.red` is "name=bucket" for every
+# failed/cancelled check, `.pending` is the names still running, `.total` is
+# how many checks were considered.
+classify() {
+  jq -c --arg run "$RUN_ID" --argjson ignore "$IGNORE" '
+    [ .[]
+      | select($run == "" or ((.link // "") | contains("/runs/" + $run + "/") | not))
+      | select(.name as $n | ($ignore | index($n)) | not)
+    ] as $c
+    | { total:   ($c | length),
+        red:     [ $c[] | select(.bucket == "fail" or .bucket == "cancel") | "\(.name)=\(.bucket)" ],
+        pending: [ $c[] | select(.bucket == "pending") | .name ] }'
+}
+
 DEADLINE=$((SECONDS + TIMEOUT))
-while [ "$SECONDS" -lt "$DEADLINE" ]; do
-  JSON=$(gh pr checks "$PR" --repo "$REPO" --json name,bucket 2>/dev/null || echo '[]')
-  TEST=$(jq -r '[.[] | select(.name=="test")] | .[0].bucket // "missing"' <<<"$JSON")
-  BUILD=$(jq -r '[.[] | select(.name=="build")] | .[0].bucket // "missing"' <<<"$JSON")
-  echo "test=$TEST build=$BUILD"
-  if [[ "$TEST" == "fail" || "$TEST" == "cancel" || "$BUILD" == "fail" || "$BUILD" == "cancel" ]]; then
-    echo "ok=false" >> "$GITHUB_OUTPUT"
-    echo "reason=\`test\`=$TEST, \`build\`=$BUILD" >> "$GITHUB_OUTPUT"
+last_pending='[]'
+while :; do
+  raw=$(gh pr checks "$PR" --repo "$REPO" --json name,bucket,link 2>/dev/null || true)
+  jq -e 'type == "array"' <<<"$raw" >/dev/null 2>&1 || raw='[]'
+  summary=$(classify <<<"$raw")
+
+  total=$(jq -r '.total' <<<"$summary")
+  red=$(jq -r '.red | join(", ")' <<<"$summary")
+  pending_n=$(jq -r '.pending | length' <<<"$summary")
+  last_pending=$(jq -c '.pending' <<<"$summary")
+  echo "checks: total=$total red=[$red] pending=$pending_n"
+
+  if [[ -n "$red" ]]; then
+    emit "ok=false"
+    emit "reason=red checks: $red"
     exit 0
   fi
-  if [[ ( "$TEST" == "pass" || "$TEST" == "skipping" ) && ( "$BUILD" == "pass" || "$BUILD" == "skipping" ) ]]; then
-    echo "ok=true" >> "$GITHUB_OUTPUT"
+  if [[ "$total" -eq 0 && "$SECONDS" -ge "$SETTLE" ]]; then
+    echo "No checks reported on this PR — nothing to wait on."
+    emit "ok=true"
     exit 0
   fi
+  if [[ "$total" -gt 0 && "$pending_n" -eq 0 ]]; then
+    emit "ok=true"
+    exit 0
+  fi
+  [ "$SECONDS" -ge "$DEADLINE" ] && break
   sleep "$POLL"
 done
-echo "ok=false" >> "$GITHUB_OUTPUT"
-echo "reason=timed out waiting for the \`test\` / \`build\` checks to complete" >> "$GITHUB_OUTPUT"
+
+names=$(jq -r 'join(", ")' <<<"$last_pending")
+emit "ok=false"
+emit "reason=timed out waiting for checks to finish: ${names:-unknown}"

--- a/.github/workflows/code-pipeline.yml
+++ b/.github/workflows/code-pipeline.yml
@@ -435,7 +435,7 @@ jobs:
           repository: ${{ steps.cfg.outputs.wiki_repo }}
           path: wiki
 
-      - name: Wait for test + build checks
+      - name: Wait for PR checks
         id: checks
         env:
           GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Four agents pick issues up by label and hand them along a fixed track:
 | **Refiner** | `status:needs-refinement` on an issue                                 | picks the type, checks the draft against the codebase and wiki, rewrites the body into the type's template, posts a blockers/dependencies comment | `status:refined` |
 | **Estimator** | `status:refined`                                                      | reads the code the Scope touches, scores blast radius / touch / human involvement / review overhead, rolls that into a size | `status:estimated` + `size:*` |
 | **Coder** | `status:ready` (human-assigned) on a `type:coding-task` or `type:bug` | implements every Acceptance Criteria item, writes tests, opens a PR that `Closes #N` | `status:in-progress`, a PR labelled `pr:in-review` |
-| **Reviewer** | a PR opened/updated by the coder (or a human)                         | waits for the `test` / `build` checks, reviews the diff against the linked issue, submits `APPROVE` or `REQUEST_CHANGES` | PR approved, or a coder fix round, or `pr:needs-attention` |
+| **Reviewer** | a PR opened/updated by the coder (or a human)                         | waits for the PR's checks to be green, reviews the diff against the linked issue, submits `APPROVE` or `REQUEST_CHANGES` | PR approved, or a coder fix round, or `pr:needs-attention` |
 
 The human owner steps in twice. First, on a refined and estimated issue: decide
 whether to run the automated implementation flow, or send the task back for
@@ -89,8 +89,8 @@ Two limits bound the loop:
   can keep pushing commits and each one still spawns a reviewer run. At 5 total
   reviews on the PR, automatic review stops entirely and stays manual.
 
-Red `test` / `build` checks also send the PR straight to `pr:needs-attention`,
-with no fix round.
+A red PR check also sends the PR straight to `pr:needs-attention`, with no fix
+round.
 
 | Label | Meaning                                      | Set by                      | Moves to |
 |---|----------------------------------------------|-----------------------------|---|
@@ -222,9 +222,10 @@ what's configurable without reading the source. Edit it, or delete a key to
 fall back to interns' own built-in default. A value can only come from this
 file or the built-in — there is no second, overlapping source.
 
-Your repo also needs `test` and `build` status checks on its PRs (from
-its own `deploy.yml` or equivalent) — the reviewer waits on them and won't run
-until both are green.
+The reviewer waits for **all** of a PR's checks to be green before it runs — a
+red or cancelled check on anything routes the PR to a human instead. Name any
+non-blocking advisory checks (preview deploys, coverage deltas) under
+`checks.ignore` in `.github/interns.yml` to keep them out of that gate.
 
 ### Doing it by hand
 
@@ -288,8 +289,8 @@ those two are implementable. Add the right type label and re-apply
 <details>
 <summary><b>A PR is stuck on <code>pr:needs-attention</code>.</b></summary>
 
-One of: the `test` / `build` checks went red (the coder is expected to push
-green — this goes straight to a human, no retry), a second review round still
+One of: a PR check went red (the coder is expected to push green — this goes
+straight to a human, no retry), a second review round still
 requested changes (the fix loop didn't converge), or the automatic-review cap
 (5 per PR) was hit. Read the PR comment the pipeline left for which. Re-engage a
 reviewer with the caller's `workflow_dispatch` (`phase: reviewer`,

--- a/templates/config/interns.yml
+++ b/templates/config/interns.yml
@@ -8,6 +8,13 @@ wiki:
   enabled: false
   # url: owner/repo.wiki
 
+# The reviewer waits for every PR check to be green before it runs. List any
+# non-blocking advisory checks here (preview deploys, coverage deltas) to keep
+# them out of that gate.
+checks:
+  ignore: []
+  #  - preview-deploy
+
 defaults:
   model: claude-sonnet-5
   max_turns: 40


### PR DESCRIPTION
Closes #39

## What

`wait-for-checks.sh` stopped inspecting two hardcoded checks (`test`, `build`) and now gates the reviewer on **every** check on the PR:

- pulls all checks via `gh pr checks <pr> --json name,bucket,link`
- any **red** check (`fail` / `cancel`) → `ok=false`, `route-red-checks.sh` sends the PR to a human (unchanged path)
- **all** non-skipped checks green (`pass`, `skipping`) → reviewer proceeds
- still **pending** → poll to `CHECK_TIMEOUT_SECONDS`, then escalate as "timed out", naming the stuck checks

### Edge cases

- **Self-deadlock** — checks whose `link` carries this run's `GITHUB_RUN_ID` are excluded, so the reviewer never waits on its own run.
- **Advisory checks** — new optional `checks.ignore` list in `.github/interns.yml` (schema + template + `agent-config.sh` allow-list updated) drops non-blocking checks (preview deploy, coverage delta) from the gate. Single source, no branch-protection fallback layer.
- **No checks yet** — a `CHECK_SETTLE_SECONDS` (30s) grace window before a check-less PR is treated as green, so checks that register a few seconds late aren't missed.
- `workflow_dispatch` still bypasses the gate entirely.

## Docs

README §2 / `pr:*` / troubleshooting no longer tell consumers to name their checks `test` and `build`; they now say the reviewer waits for all PR checks and point at `checks.ignore`.

## Tests

`wait-for-checks.bats` rewritten: one red among several green, all green, cancelled-as-red, a pending check that later passes, self-exclusion, `checks.ignore`, timeout, no-checks. Full suite: 96/96. `shellcheck -x` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)