### PR TITLE
feat(refine): let the refiner rewrite the issue title

### DIFF
--- a/.github/prompts/refine.md
+++ b/.github/prompts/refine.md
@@ -62,12 +62,18 @@ Use this to write a more accurate and *narrower* Scope. Investigation
 sharpens the ticket; it does not license adding scope the draft didn't ask
 for.
 
-## Step 3: rewrite the body
+## Step 3: rewrite the body and title
 
 Rewrite the body into the chosen structure, carrying over every concrete
 requirement already in the original text. Ground each section in what Step
 2 found — name the real files, jobs, and patterns rather than describing
 the work abstractly.
+
+The title was user-typed when the issue was filed and is never revisited
+otherwise. Once the body is rewritten, check the title against it: if the
+title is vague, mislabeled, or no longer matches what the refined body
+describes, rewrite it into a short, specific summary of the corrected body.
+Leave it untouched if it's already accurate — don't reword a fine title.
 
 The rewritten description must be **concise and specific** — tighter than
 the draft you were given, not longer. Cut restatement, hedging, and

--- a/.github/scripts/gh-safe/edit-issue-title.sh
+++ b/.github/scripts/gh-safe/edit-issue-title.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Sets the title of the issue bound to the triggering event, reading the
+# new title from a fixed file (written beforehand with the Write tool).
+# Content never passes through a Bash argument, matching edit-issue-body.sh
+# and keeping titles with shell metacharacters out of the command line.
+#
+# Usage: write the new title to $TITLE_FILE, then run with no arguments.
+
+set -euo pipefail
+
+TITLE_FILE="${TITLE_FILE:-./.issue-pipeline-title.md}"
+
+ISSUE=$(jq -r '.issue.number // .inputs.issue_number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "Error: no issue number in event payload" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TITLE_FILE" ]]; then
+  echo "Error: $TITLE_FILE not found — write the new title there first" >&2
+  exit 1
+fi
+
+# A title is a single line; collapse any trailing newline and reject a
+# multi-line file rather than silently sending only the first line.
+if [[ $(grep -c '' "$TITLE_FILE") -gt 1 ]]; then
+  echo "Error: $TITLE_FILE has more than one line — a title is a single line" >&2
+  exit 1
+fi
+
+TITLE=$(head -n 1 "$TITLE_FILE")
+if [[ -z "$TITLE" ]]; then
+  echo "Error: $TITLE_FILE is empty" >&2
+  exit 1
+fi
+
+gh issue edit "$ISSUE" --title "$TITLE"

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -34,6 +34,7 @@ env:
   # form the agent might type it in: relative with ./, relative without it,
   # and workspace-absolute.
   ALLOWED_EDIT_BODY: "Bash(./.interns/.github/scripts/gh-safe/edit-issue-body.sh:*),Bash(.interns/.github/scripts/gh-safe/edit-issue-body.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/edit-issue-body.sh:*)"
+  ALLOWED_EDIT_TITLE: "Bash(./.interns/.github/scripts/gh-safe/edit-issue-title.sh:*),Bash(.interns/.github/scripts/gh-safe/edit-issue-title.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/edit-issue-title.sh:*)"
   ALLOWED_EDIT_LABELS: "Bash(./.interns/.github/scripts/gh-safe/edit-issue-labels.sh:*),Bash(.interns/.github/scripts/gh-safe/edit-issue-labels.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/edit-issue-labels.sh:*)"
   ALLOWED_COMMENT: "Bash(./.interns/.github/scripts/gh-safe/comment-issue.sh:*),Bash(.interns/.github/scripts/gh-safe/comment-issue.sh:*),Bash(${{ github.workspace }}/.interns/.github/scripts/gh-safe/comment-issue.sh:*)"
 
@@ -130,18 +131,22 @@ jobs:
             1. Investigate the draft against the repo and wiki (refine.md
                Step 2), then write the new body to ./.issue-pipeline-body.md
             2. Run ./.interns/.github/scripts/gh-safe/edit-issue-body.sh (no args)
-            3. Write the blockers/dependencies analysis (refine.md Step 4)
+            3. If the title no longer describes the refined body (refine.md
+               Step 3), write the corrected title to ./.issue-pipeline-title.md
+               and run ./.interns/.github/scripts/gh-safe/edit-issue-title.sh
+               (no args). Leave the title as-is if it's already accurate.
+            4. Write the blockers/dependencies analysis (refine.md Step 4)
                to ./.issue-pipeline-comment.md and run
                ./.interns/.github/scripts/gh-safe/comment-issue.sh (no args)
-            4. Swap labels:
+            5. Swap labels:
                ./.interns/.github/scripts/gh-safe/edit-issue-labels.sh --remove-label "status:needs-refinement" --add-label "status:refined"
 
             Post exactly the one analysis comment described in refine.md —
-            no other comments, no edits beyond the body and labels.
+            no other comments, no edits beyond the title, body, and labels.
           claude_args: |
             --model ${{ steps.cfg.outputs.model }}
             --max-turns ${{ steps.cfg.outputs.max_turns }}
-            --allowedTools "Read,Grep,Glob,Write,${{ env.ALLOWED_EDIT_BODY }},${{ env.ALLOWED_EDIT_LABELS }},${{ env.ALLOWED_COMMENT }}"
+            --allowedTools "Read,Grep,Glob,Write,${{ env.ALLOWED_EDIT_BODY }},${{ env.ALLOWED_EDIT_TITLE }},${{ env.ALLOWED_EDIT_LABELS }},${{ env.ALLOWED_COMMENT }}"
 
       - name: Report run cost
         if: always() && steps.claude.outputs.execution_file != ''

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Four agents pick issues up by label and hand them along a fixed track:
 
 | Agent | Trigger                                                               | Does | Leaves |
 |---|-----------------------------------------------------------------------|---|---|
-| **Refiner** | `status:needs-refinement` on an issue                                 | picks the type, checks the draft against the codebase and wiki, rewrites the body into the type's template, posts a blockers/dependencies comment | `status:refined` |
+| **Refiner** | `status:needs-refinement` on an issue                                 | picks the type, checks the draft against the codebase and wiki, rewrites the body into the type's template (and the title if it no longer fits), posts a blockers/dependencies comment | `status:refined` |
 | **Estimator** | `status:refined`                                                      | reads the code the Scope touches, scores blast radius / touch / human involvement / review overhead, rolls that into a size | `status:estimated` + `size:*` |
 | **Coder** | `status:ready` (human-assigned) on a `type:coding-task` or `type:bug` | implements every Acceptance Criteria item, writes tests, opens a PR that `Closes #N` | `status:in-progress`, a PR labelled `pr:in-review` |
 | **Reviewer** | a PR opened/updated by the coder (or a human)                         | waits for the PR's checks to be green, reviews the diff against the linked issue, submits `APPROVE` or `REQUEST_CHANGES` | PR approved, or a coder fix round, or `pr:needs-attention` |
@@ -180,7 +180,7 @@ to skip it.
 |---|---|---|
 | Contents | Read and write | push branches |
 | Pull requests | Read and write | open PRs, submit reviews, comment |
-| Issues | Read and write | edit labels, comment, rewrite the issue body (the refiner) |
+| Issues | Read and write | edit labels, comment, rewrite the issue title and body (the refiner) |
 | Checks | Read | reviewer reads check results |
 | Metadata | Read | mandatory baseline |
 


### PR DESCRIPTION
Closes #41

## Problem

The refiner rewrites the issue body to match reality but is explicitly
forbidden from touching the title. A refined issue can end up with a
user-typed title that no longer describes its own corrected body.

## Changes

- **New wrapper `.github/scripts/gh-safe/edit-issue-title.sh`** — mirrors
  `edit-issue-body.sh`: reads the new title from `./.issue-pipeline-title.md`
  (never a Bash arg), enforces a single non-empty line, then
  `gh issue edit --title`.
- **`issue-pipeline.yml`** — adds `ALLOWED_EDIT_TITLE`, wires it into the
  refine phase `--allowedTools`, and adds a prompt step: after the body
  edit, rewrite the title if it no longer fits (leave it alone otherwise).
  Wording changed from "no edits beyond the body and labels" to
  "beyond the title, body, and labels".
- **`refine.md`** — Step 3 renamed to "rewrite the body and title" and
  now instructs checking the title against the refined body.
- **`README.md`** — refiner row and the Apps permission table mention the
  title alongside body/labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)