### PR TITLE
feat(pipeline): deterministic issue-type gates; refiner stops classifying epics

### DIFF
--- a/.github/actions/gate-issue-type/action.yml
+++ b/.github/actions/gate-issue-type/action.yml
@@ -1,0 +1,36 @@
+name: gate-issue-type
+description: Deterministic issue-type gate — park the issue and signal skip when its type:* label isn't accepted
+
+inputs:
+  issue_number:
+    description: Issue number to gate
+    required: true
+  accepted_types:
+    description: Comma-separated type:* labels the calling job can handle
+    required: true
+  remove_status:
+    description: status:* label to remove when parking a rejected issue
+    required: true
+  reject_comment:
+    description: Comment body posted on a rejected issue
+    required: true
+
+outputs:
+  skip:
+    description: "'true' when the issue's type isn't accepted and the caller must not run its agent"
+    value: ${{ steps.gate.outputs.skip }}
+
+runs:
+  using: composite
+  steps:
+    - name: Gate
+      id: gate
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        ISSUE: ${{ inputs.issue_number }}
+        ACCEPTED: ${{ inputs.accepted_types }}
+        REMOVE_STATUS: ${{ inputs.remove_status }}
+        REJECT_COMMENT: ${{ inputs.reject_comment }}
+      run: ${{ github.action_path }}/../../scripts/pipeline/gate-issue-type.sh

--- a/.github/prompts/estimate.md
+++ b/.github/prompts/estimate.md
@@ -3,13 +3,6 @@ You are estimating effort for a refined issue.
 Input: the issue title, its refined body (Value / Scope / Acceptance
 Criteria), and any comments on it.
 
-If the issue has a `type:epic` label, do not estimate it. Epics are intent
-and scope, not a sized deliverable — sizing them in dev-effort terms
-doesn't mean anything before they're broken into sub-issues. Instead,
-comment on the issue explaining that epics aren't estimated directly (size
-the sub-issues once they're filed), and swap labels:
-`--remove-label "status:refined" --add-label "status:ready"`. Then stop.
-
 Assume coding itself is cheap — most tickets are implemented by an AI
 coding agent. The real cost is whatever the owner personally has to touch:
 risk, review, and anything an agent can't verify itself. Size against that
@@ -76,6 +69,15 @@ SIZE: <XS|S|M|L|XL>
 <one sentence on which criterion or criteria drove the size>
 
 Output nothing else — no preamble, no closing remarks.
+
+## Spikes
+
+A `type:spike` is sized the same way — the estimate tells the owner whether
+the investigation is worth their time. A spike's pipeline path ends here: no
+coder picks it up. Add one line above the format block in your comment:
+
+> This is a spike; no coder picks it up. The estimate is for your planning.
+> Do the investigation and close when done.
 
 ## When to stop instead of estimating
 

--- a/.github/prompts/refine.md
+++ b/.github/prompts/refine.md
@@ -8,18 +8,22 @@ issue is not just a reshaped draft — it is a draft checked against reality.
 
 ## Step 1: pick the type
 
-Four issue types exist. Determine which one applies:
+Three issue types exist. Determine which one applies:
 
 - `spike` — research or a decision, no code deliverable
 - `bug` — something is broken
 - `coding-task` — pure implementation work
-- `epic` — a raw idea or theme that will break down into several tickets;
-  no Acceptance Criteria, since the work itself isn't scoped yet
+
+You may set `type:spike`, `type:bug`, or `type:coding-task` only. **You may
+not set `type:epic`.** Declaring something an epic is a human's call; if the
+issue is epic-sized, take the stop-and-comment path below.
 
 Rules:
 
-- If the issue already has a `type:spike`, `type:bug`, `type:coding-task`,
-  or `type:epic` label, use that — do not second-guess it.
+- If the issue already has a `type:spike`, `type:bug`, or `type:coding-task`
+  label, use that — do not second-guess it.
+- If it already has `type:epic`, stop and comment (see below) — an epic is
+  not refined here.
 - Otherwise, infer the type from the title and body.
 - If it's genuinely ambiguous between two types (not just unclear in
   detail, but shaped differently enough that the type choice changes what
@@ -122,10 +126,9 @@ Rules for the comment:
 
 ## When to stop instead of refining
 
-Two cases justify stopping and commenting on the issue (tagging the owner,
-whose handle is in your instructions) with one specific, answerable
-question, then reporting that you stopped for clarification instead of
-editing the body:
+Three cases justify stopping and commenting on the issue (tagging the owner,
+whose handle is in your instructions), then reporting that you stopped
+instead of editing the body:
 
 1. **Blocking ambiguity** — you cannot fill a section without guessing at a
    fact only the owner would know: not a missing detail you can flag inline
@@ -135,6 +138,13 @@ editing the body:
    exist yet (an unbuilt system, an undecided design, a blocked
    dependency), so scoping it now would be guesswork. Say what's missing
    and that refinement should wait until it lands.
+3. **Epic-sized** — the issue isn't a single deliverable but several
+   separate tickets' worth of work. The line: a large-but-single task is an
+   XL `type:coding-task` (one coherent change, one PR, even if big) — refine
+   it normally. An epic is genuinely several independent deliverables that
+   would each be filed and shipped on their own. If it's an epic, ask the
+   human to label the parent `type:epic` and break it into sub-issues.
 
-In the stop case, post only the clarification comment — no separate
-analysis comment, and don't touch the body.
+For each, comment with one specific, answerable request. In the stop case,
+post only that comment — no separate analysis comment, and don't touch the
+body.

--- a/.github/scripts/pipeline/gate-issue-type.sh
+++ b/.github/scripts/pipeline/gate-issue-type.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Deterministic issue-type gate, shared by the estimate and code jobs. An issue
+# whose type:* label isn't in the accepted list never reaches an agent: post a
+# comment, park the issue on status:needs-attention, and tell the calling job to
+# skip its Claude step. Running a full agent invocation just to execute a fixed
+# `if` on a label already present when the job starts is wasteful and fragile.
+#
+# Invoked by the gate-issue-type composite action, which passes everything in the
+# environment:
+#   GH_TOKEN, GITHUB_REPOSITORY, GITHUB_OUTPUT   standard Actions env
+#   ISSUE           issue number
+#   ACCEPTED        comma-separated type:* labels the calling job can handle
+#   REMOVE_STATUS   status:* label to drop when parking a rejected issue
+#   REJECT_COMMENT  comment body posted on a rejected issue
+
+set -euo pipefail
+
+labels=$(gh issue view "$ISSUE" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")')
+
+IFS=',' read -ra want <<<"$ACCEPTED"
+for type in "${want[@]}"; do
+  if [[ ",$labels," == *",$type,"* ]]; then
+    echo "Issue #$ISSUE is $type — accepted."
+    echo "skip=false" >>"$GITHUB_OUTPUT"
+    exit 0
+  fi
+done
+
+echo "Issue #$ISSUE type is not one of {$ACCEPTED} (labels: $labels) — parking on status:needs-attention."
+gh issue edit "$ISSUE" --repo "$GITHUB_REPOSITORY" \
+  --add-label status:needs-attention --remove-label "$REMOVE_STATUS" || true
+gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body "$REJECT_COMMENT"
+echo "skip=true" >>"$GITHUB_OUTPUT"

--- a/.github/scripts/pipeline/tests/gate-issue-type.bats
+++ b/.github/scripts/pipeline/tests/gate-issue-type.bats
@@ -1,0 +1,46 @@
+setup() {
+  load helpers
+  setup_stubs
+  export ISSUE=42 GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output"
+  : >"$GITHUB_OUTPUT"
+}
+
+gate() { "$PIPELINE_DIR/gate-issue-type.sh"; }
+
+@test "accepts an issue whose type is in the list — no edit, no comment" {
+  export STUB_ISSUE_LABELS="type:coding-task,status:refined"
+  export ACCEPTED="type:coding-task,type:bug,type:spike" REMOVE_STATUS="status:refined" REJECT_COMMENT="nope"
+  run gate
+  [ "$status" -eq 0 ]
+  grep -q 'skip=false' "$GITHUB_OUTPUT"
+  ! grep -q 'gh issue edit' "$STUB_LOG"
+  ! grep -q 'gh issue comment' "$STUB_LOG"
+}
+
+@test "accepts on a match anywhere in the accepted list" {
+  export STUB_ISSUE_LABELS="type:spike,status:refined"
+  export ACCEPTED="type:coding-task,type:bug,type:spike" REMOVE_STATUS="status:refined" REJECT_COMMENT="nope"
+  run gate
+  [ "$status" -eq 0 ]
+  grep -q 'skip=false' "$GITHUB_OUTPUT"
+}
+
+@test "rejects an epic — parks it, comments, signals skip" {
+  export STUB_ISSUE_LABELS="type:epic,status:refined"
+  export ACCEPTED="type:coding-task,type:bug,type:spike" REMOVE_STATUS="status:refined" \
+    REJECT_COMMENT="Epics aren't sized directly."
+  run gate
+  [ "$status" -eq 0 ]
+  grep -q 'skip=true' "$GITHUB_OUTPUT"
+  grep -q 'gh issue edit 42 --repo owner/repo --add-label status:needs-attention --remove-label status:refined' "$STUB_LOG"
+  grep -q "gh issue comment 42 .* Epics aren't sized directly." "$STUB_LOG"
+}
+
+@test "coder gate drops status:ready when it rejects a spike" {
+  export STUB_ISSUE_LABELS="type:spike,status:ready"
+  export ACCEPTED="type:coding-task,type:bug" REMOVE_STATUS="status:ready" REJECT_COMMENT="not implementable"
+  run gate
+  [ "$status" -eq 0 ]
+  grep -q 'skip=true' "$GITHUB_OUTPUT"
+  grep -q 'gh issue edit 42 --repo owner/repo --add-label status:needs-attention --remove-label status:ready' "$STUB_LOG"
+}

--- a/.github/workflows/code-pipeline.yml
+++ b/.github/workflows/code-pipeline.yml
@@ -118,6 +118,25 @@ jobs:
         with:
           issue_number: ${{ github.event.issue.number || inputs.issue_number }}
 
+      # Deterministic type gate: only type:coding-task and type:bug are
+      # implementable. status:ready can also land on a spike or (via a manual
+      # mislabel) an epic — the coder should never attempt either. Shared with
+      # the estimate job's gate. Skipped on a fix round: the issue is already
+      # status:in-progress and its type hasn't changed.
+      - name: Gate issue type
+        id: gate
+        if: inputs.fix_round != 'true'
+        uses: ./.interns/.github/actions/gate-issue-type
+        with:
+          issue_number: ${{ steps.issue.outputs.number }}
+          accepted_types: type:coding-task,type:bug
+          remove_status: status:ready
+          reject_comment: >-
+            This issue reached `status:ready` without a `type:coding-task` or
+            `type:bug` label, so the coder agent won't attempt it — only those
+            two types are implementable code deliverables. If this should be
+            implemented, add the correct type label and re-apply `status:ready`.
+
       - name: Guard against duplicate or stale trigger
         id: guard
         env:
@@ -125,25 +144,18 @@ jobs:
         run: |
           NUM="${{ steps.issue.outputs.number }}"
           FIX_ROUND="${{ inputs.fix_round }}"
-          LABELS=$(gh issue view "$NUM" --repo ${{ github.repository }} --json labels --jq '[.labels[].name] | join(",")')
-          echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
           echo "fix_round=$FIX_ROUND" >> "$GITHUB_OUTPUT"
+          if [[ "${{ steps.gate.outputs.skip }}" == "true" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          LABELS=$(gh issue view "$NUM" --repo ${{ github.repository }} --json labels --jq '[.labels[].name] | join(",")')
           # A fix round is an explicit dispatch from the reviewer against an issue
           # that is *already* status:in-progress — the stale-trigger guard below
           # would wrongly skip it, so let it through.
           if [[ "$FIX_ROUND" != "true" ]] && \
              [[ "$LABELS" == *"status:in-progress"* || "$LABELS" == *"status:needs-attention"* ]]; then
             echo "Issue #$NUM is already past status:ready ($LABELS) — stale or duplicate trigger, skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$LABELS" != *"type:coding-task"* && "$LABELS" != *"type:bug"* ]]; then
-            # Deterministic type gate: only type:coding-task and type:bug are
-            # implementable. status:ready can also land on an epic (via its
-            # estimate-phase bypass) or a spike, neither of which the coder
-            # should ever attempt — see #112.
-            echo "Issue #$NUM is not type:coding-task or type:bug ($LABELS) — not implementable, escalating."
-            gh issue edit "$NUM" --repo ${{ github.repository }} \
-              --add-label "status:needs-attention" --remove-label "status:ready"
-            gh issue comment "$NUM" --repo ${{ github.repository }} --body "This issue reached \`status:ready\` without a \`type:coding-task\` or \`type:bug\` label, so the coder agent won't attempt it — only those two types are implementable code deliverables. If this should be implemented, add the correct type label and re-apply \`status:ready\`."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -246,8 +246,24 @@ jobs:
         with:
           issue_number: ${{ github.event.issue.number || inputs.issue_number }}
 
+      # Deterministic backstop: the refiner can no longer produce a type:epic, so
+      # on the happy path the estimator never sees one. This catches a manual
+      # mislabel or a workflow_dispatch — a pure label transition, no agent.
+      - name: Gate issue type
+        id: gate
+        uses: ./.interns/.github/actions/gate-issue-type
+        with:
+          issue_number: ${{ steps.issue.outputs.number }}
+          accepted_types: type:coding-task,type:bug,type:spike
+          remove_status: status:refined
+          reject_comment: >-
+            Epics aren't sized directly — a dev-effort number doesn't mean
+            anything before the work is broken down. Break this into sub-issues
+            and estimate those.
+
       - name: Run Claude estimation
         id: claude
+        if: steps.gate.outputs.skip != 'true'
         timeout-minutes: ${{ fromJSON(steps.cfg.outputs.timeout_minutes) }}
         uses: anthropics/claude-code-action@v1
         env:
@@ -331,7 +347,7 @@ jobs:
         run: >
           .interns/.github/scripts/pipeline/verify-outcome.sh Estimation
           "${{ steps.issue.outputs.number }}"
-          status:estimated status:ready status:needs-attention
+          status:estimated status:needs-attention
 
       - name: Write run summary
         if: always() && steps.claude.outcome != 'skipped'

--- a/README.md
+++ b/README.md
@@ -109,12 +109,16 @@ signal. List the PRs waiting on a human with
 | `type:coding-task` | yes | yes |
 | `type:bug` | yes | yes |
 | `type:spike` | yes | no — a human does the investigation |
-| `type:epic` | no — refiner refuses it up front | no — a human breaks it into sub-issues |
+| `type:epic` | no — refiner rejects epic-sized issues to `status:needs-attention` | no — a human breaks it into sub-issues |
 
-Spikes and epics are never implemented automatically. A spike is refined and
-estimated, then bounced to `status:needs-attention` at the coder's type gate. An
-epic doesn't even get refined — the refiner refuses it. Either way, a human
-takes it from there.
+Spikes and epics are never implemented automatically. A spike's pipeline path
+**ends at `status:estimated`** — the estimate exists so the owner can judge
+whether the investigation is worth their time; they then do the work and close
+the issue. There is no spike greenlight: `status:ready` is coder-only, so moving
+a spike there is a mistake, and the coder's type gate bounces it to
+`status:needs-attention`. An epic doesn't get refined at all — the refiner
+rejects epic-sized issues to `status:needs-attention` and a human breaks them
+into sub-issues. Either way, a human takes it from there.
 
 ### `size:*` and `priority:*`
 


### PR DESCRIPTION
Closes #36

## What changed

### Shared mechanism
- **`.github/actions/gate-issue-type`** — composite action parameterised by an accepted-types list, wrapping **`.github/scripts/pipeline/gate-issue-type.sh`**. When an issue's `type:*` label isn't accepted it posts a comment, moves the issue to `status:needs-attention` (dropping the caller's status label), and outputs `skip=true`. One implementation, one `bats` suite, matching the existing `.github/actions/*` pattern.

### Estimator
- The `estimate` job in `issue-pipeline.yml` gains a deterministic **Gate issue type** step before the Claude step (accepts `type:coding-task`, `type:bug`, `type:spike`; rejects `type:epic`). Backstop for a manual mislabel or `workflow_dispatch` — on the happy path the refiner can no longer produce an epic.
- Deleted the `type:epic` branch from `estimate.md` (a pure label transition dressed up as an LLM instruction).
- Dropped the now-dead `status:ready` outcome from the estimator's `verify-outcome.sh` call.
- Downstream cost/metrics/verify/summary steps already no-op when the Claude step is skipped (they gate on `execution_file`/`outcome`), so no extra conditions were needed.

### Coder
- Replaced the inline type gate in `code-pipeline.yml`'s "Guard against duplicate or stale trigger" with the shared action. The stale/duplicate-trigger check stays inline. Gate is skipped on a fix round (issue already `status:in-progress`). Rejecting a spike/epic drops the erroneous `status:ready` in the same step.

### Refiner
- `refine.md`: three types only (`spike`/`bug`/`coding-task`); **may not set `type:epic`**. Epic-sized work takes the existing stop-and-comment path, with an explicit boundary — a large-but-single change is an XL `type:coding-task`; an epic is several independent deliverables.

### Spike lifecycle (docs)
- `estimate.md`: spikes are sized normally, but the path ends at `status:estimated` — one-line note added to the estimator's comment.
- `README.md`: spike terminates at `status:estimated`; the `type:epic` table row and the "spikes and epics" paragraph reworded.

## Testing
- `bats .github/scripts/pipeline/tests` — 105 pass (4 new for the gate).
- `shellcheck -x` clean; `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
