### PR TITLE
feat(refine): resolve the issue template in code, not by prompt globbing

### DIFF
--- a/.github/actions/resolve-issue-template/action.yml
+++ b/.github/actions/resolve-issue-template/action.yml
@@ -1,0 +1,20 @@
+name: resolve-issue-template
+description: >
+  Resolve each refineable issue type's section skeleton for the refiner prompt:
+  consumer-repo override wins, frontmatter and HTML comments stripped, headings
+  in order.
+
+outputs:
+  skeleton:
+    description: One block per type — `type:<name>` header followed by its heading lines
+    value: ${{ steps.resolve.outputs.skeleton }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve issue templates
+      id: resolve
+      shell: bash
+      env:
+        BUILTIN_DIR: ${{ github.action_path }}/../../../templates/issue
+      run: ${{ github.action_path }}/../../scripts/pipeline/resolve-issue-template.sh

--- a/.github/prompts/refine.md
+++ b/.github/prompts/refine.md
@@ -30,17 +30,11 @@ Rules:
   the ticket even asks for), that's the kind of blocking ambiguity covered
   in the clarification rule below — ask the owner instead of guessing.
 
-Then read the template for that type and use its exact section structure —
-same headings, same order. Look in this order and use the first that
-exists:
-
-1. the consuming repo's `.github/ISSUE_TEMPLATE/<type>.md` (so a
-   refiner-written issue matches what humans see in the New Issue picker)
-2. `.interns/templates/issue/<type>.md` — the built-in default, always
-   present
-
-Ignore the YAML frontmatter and HTML comments; they're authoring guidance,
-not body content.
+The refined body (Step 3) uses the section structure given for that type
+in `TEMPLATE`, a prompt input — same headings, same order. `TEMPLATE`
+arrives already resolved: the consumer repo's override applied where it
+has one, frontmatter and HTML comments stripped, one `type:<name>` block
+per type. Use the block whose header matches the type you picked.
 
 ## Step 2: investigate
 

--- a/.github/scripts/pipeline/resolve-issue-template.sh
+++ b/.github/scripts/pipeline/resolve-issue-template.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Resolve the section skeleton the refiner rewrites an issue body into, in
+# code rather than by globbing paths in the prompt. For each refineable issue
+# type it picks one template — the consumer repo's
+# `.github/ISSUE_TEMPLATE/<type>.md` when present, otherwise the built-in
+# `templates/issue/<type>.md` — drops the YAML frontmatter and HTML comments,
+# and emits the headings in order. The refiner picks the type, then rewrites
+# into the matching block; it never resolves a path itself.
+#
+# Appends `skeleton` to $GITHUB_OUTPUT: one block per type, each headed by the
+# `type:<name>` label and followed by that template's heading lines.
+#
+# Env:
+#   BUILTIN_DIR   dir holding the built-in templates/issue/<type>.md (required)
+#   CONSUMER_DIR  dir checked for per-type overrides (default .github/ISSUE_TEMPLATE)
+#   TYPES         space-separated type names (default "coding-task bug spike")
+
+set -euo pipefail
+
+builtin_dir="${BUILTIN_DIR:?BUILTIN_DIR not set}"
+consumer_dir="${CONSUMER_DIR:-.github/ISSUE_TEMPLATE}"
+read -ra types <<<"${TYPES:-coding-task bug spike}"
+
+# Strip the leading YAML frontmatter block, then keep only markdown heading
+# lines. HTML comments in these templates never start with `#`, so filtering
+# to heading lines drops them for free.
+headings() {
+  awk '
+    NR == 1 && $0 == "---" { fm = 1; next }
+    fm && $0 == "---"      { fm = 0; next }
+    fm                     { next }
+    /^#{1,6} /             { print }
+  ' "$1"
+}
+
+{
+  echo 'skeleton<<EOF_SKELETON'
+  for type in "${types[@]}"; do
+    template="$builtin_dir/$type.md"
+    [[ -f "$consumer_dir/$type.md" ]] && template="$consumer_dir/$type.md"
+    [[ -f "$template" ]] || { echo "resolve-issue-template: no template for '$type'" >&2; exit 1; }
+
+    echo "type:$type"
+    headings "$template"
+    echo
+  done
+  echo 'EOF_SKELETON'
+} >>"${GITHUB_OUTPUT:?GITHUB_OUTPUT not set}"

--- a/.github/scripts/pipeline/tests/resolve-issue-template.bats
+++ b/.github/scripts/pipeline/tests/resolve-issue-template.bats
@@ -1,0 +1,43 @@
+setup() {
+  load helpers
+  PIPELINE_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  BUILTIN="$BATS_TEST_TMPDIR/builtin"
+  CONSUMER="$BATS_TEST_TMPDIR/consumer"
+  mkdir -p "$BUILTIN" "$CONSUMER"
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output"
+  : >"$GITHUB_OUTPUT"
+
+  printf -- '---\nlabels: type:coding-task\n---\n## Value\n<!-- why -->\n## Scope\n' >"$BUILTIN/coding-task.md"
+  printf -- '---\nlabels: type:bug\n---\n## Description\n## Impact\n' >"$BUILTIN/bug.md"
+  printf -- '## Question to Answer\n' >"$BUILTIN/spike.md"
+}
+
+resolve() {
+  BUILTIN_DIR="$BUILTIN" CONSUMER_DIR="$CONSUMER" TYPES="coding-task bug spike" \
+    "$PIPELINE_DIR/resolve-issue-template.sh"
+}
+
+@test "emits a heading-only block per type, frontmatter and comments gone" {
+  run resolve
+  [ "$status" -eq 0 ]
+  skel="$(sed -n '/^skeleton<<EOF_SKELETON$/,/^EOF_SKELETON$/p' "$GITHUB_OUTPUT")"
+  [[ "$skel" == *"type:coding-task"$'\n'"## Value"$'\n'"## Scope"* ]]
+  [[ "$skel" == *"type:bug"$'\n'"## Description"$'\n'"## Impact"* ]]
+  [[ "$skel" != *"---"* ]]
+  [[ "$skel" != *"<!--"* ]]
+}
+
+@test "consumer override wins when present" {
+  printf -- '---\nlabels: type:bug\n---\n## Custom\n## Fields\n' >"$CONSUMER/bug.md"
+  run resolve
+  [ "$status" -eq 0 ]
+  grep -q '## Custom' "$GITHUB_OUTPUT"
+  ! grep -q '## Description' "$GITHUB_OUTPUT"
+}
+
+@test "fails when a type has no template anywhere" {
+  rm "$BUILTIN/spike.md"
+  run resolve
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no template for 'spike'"* ]]
+}

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -81,6 +81,10 @@ jobs:
         with:
           issue_number: ${{ github.event.issue.number || inputs.issue_number }}
 
+      - name: Resolve issue template
+        id: template
+        uses: ./.interns/.github/actions/resolve-issue-template
+
       - name: Preserve original body
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -109,6 +113,10 @@ jobs:
             ${{ steps.issue.outputs.body }}
 
             ${{ steps.issue.outputs.comments }}
+
+            TEMPLATE (section skeleton per issue type — after you pick the
+            type, rewrite the body into the block whose `type:` header matches):
+            ${{ steps.template.outputs.skeleton }}
 
             Read .interns/.github/prompts/refine.md for the exact rewrite rules and
             apply them to the issue and comments above to produce a new


### PR DESCRIPTION
Closes #54

## What

The refiner resolved which issue template to use inside the prompt — try
`.github/ISSUE_TEMPLATE/<type>.md`, fall back to the built-in
`templates/issue/<type>.md`, then "ignore the frontmatter and HTML comments."
All deterministic given the type, and a first-that-exists fallback chain of
the kind avoided elsewhere.

## Changes

- **`.github/scripts/pipeline/resolve-issue-template.sh`** + **`.github/actions/resolve-issue-template`** — for each refineable type (`coding-task`, `bug`, `spike`), pick the consumer override when present else the built-in, strip YAML frontmatter and HTML comments, output the headings in order as a `type:<name>` block.
- **`issue-pipeline.yml`** (refine job) — run the action, inject its output into the prompt as `TEMPLATE:`.
- **`refine.md`** — replace the path list / "first that exists" block with "rewrite into the block whose `type:` header matches the type you picked."
- Bats coverage for override precedence, stripping, and the missing-template error.

The refiner still picks the type, so all three skeletons are passed and it
selects the matching block.

## Verified

- `bats .github/scripts/pipeline/tests` (new file green)
- `shellcheck -x` on the new script
- `actionlint` on the workflow