### PR TITLE
feat(pipeline): give the coder deterministic commit-type and branch hints

### DIFF
--- a/.github/prompts/code.md
+++ b/.github/prompts/code.md
@@ -45,18 +45,20 @@ them green, stop and comment on the issue instead.
 
 ## Branch and commit
 
-Branch name: `<type>/<short-slug>`, matching the type your PR title will
-carry — e.g. `feat/quiz-export` for a PR titled `feat: ...`. Commit your
-changes with a normal, clear commit message. `push-branch.sh` collapses the
-branch to a single commit before pushing, so don't rely on your
-intermediate commit structure surviving.
+Use the branch name given as `BRANCH` in your prompt — it's derived from
+the issue and already matches the commit type. Commit your changes with a
+normal, clear commit message. `push-branch.sh` collapses the branch to a
+single commit before pushing, so don't rely on your intermediate commit
+structure surviving.
 
 ## Open the PR
 
 PR title: a [Conventional Commit](https://www.conventionalcommits.org/)
-subject line (`feat:`, `fix:`, `refactor:`, etc.). If the repo
-squash-merges and derives releases from commit history, this line becomes
-that commit — get the type right.
+subject line. Use `COMMIT_TYPE_HINT` from your prompt as the prefix — it's
+derived from the issue's type label. Override it only when the change is
+genuinely a different type (e.g. a `type:coding-task` that is really a
+`fix:`), and say so in one line in the PR body. If the repo squash-merges
+and derives releases from commit history, this line becomes that commit.
 
 PR body: a concise, meaningful summary of what changed and why — readable
 on its own without needing to open the issue.

--- a/.github/scripts/pipeline/derive-code-hints.sh
+++ b/.github/scripts/pipeline/derive-code-hints.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Derives two deterministic hints for the initial coder run and writes them to
+# $GITHUB_OUTPUT:
+#   commit_type_hint  Conventional Commit prefix for the PR title (`fix:` / `feat:`)
+#   branch            branch name `<prefix>/issue-<n>-<slug>` from the issue title
+#
+# Both are computable from the issue's type:* label and title before the agent
+# starts, so the agent shouldn't spend reasoning inventing them. push-branch.sh
+# squashes the branch on push, so the branch name is near-cosmetic. Runs after
+# the issue-type gate, which guarantees a type:coding-task or type:bug label.
+#
+# Usage: derive-code-hints.sh <issue-number>
+
+set -euo pipefail
+
+ISSUE="$1"
+REPO="$GITHUB_REPOSITORY"
+
+labels=$(gh issue view "$ISSUE" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')
+title=$(gh issue view "$ISSUE" --repo "$REPO" --json title --jq .title)
+
+if [[ ",$labels," == *",type:bug,"* ]]; then
+  prefix=fix
+elif [[ ",$labels," == *",type:coding-task,"* ]]; then
+  prefix=feat
+else
+  echo "Error: issue #$ISSUE has neither type:bug nor type:coding-task (labels: $labels)" >&2
+  exit 1
+fi
+
+slug=$(printf '%s' "$title" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+  | cut -c1-40 \
+  | sed -E 's/-+$//')
+
+{
+  echo "commit_type_hint=${prefix}:"
+  echo "branch=${prefix}/issue-${ISSUE}-${slug}"
+} >>"$GITHUB_OUTPUT"

--- a/.github/scripts/pipeline/tests/derive-code-hints.bats
+++ b/.github/scripts/pipeline/tests/derive-code-hints.bats
@@ -1,0 +1,40 @@
+setup() {
+  load helpers
+  setup_stubs
+}
+
+derive() { "$PIPELINE_DIR/derive-code-hints.sh" 42; }
+
+@test "type:coding-task maps to feat: and a feat/ branch" {
+  export STUB_ISSUE_LABELS="type:coding-task,status:ready"
+  export STUB_ISSUE_TITLE="Pass the coder deterministic commit-type hints"
+  run derive
+  [ "$status" -eq 0 ]
+  grep -q 'commit_type_hint=feat:' "$GITHUB_OUTPUT"
+  grep -q 'branch=feat/issue-42-pass-the-coder-deterministic-commit-typ' "$GITHUB_OUTPUT"
+}
+
+@test "type:bug maps to fix: and a fix/ branch" {
+  export STUB_ISSUE_LABELS="type:bug,status:ready"
+  export STUB_ISSUE_TITLE="Crash on empty input"
+  run derive
+  [ "$status" -eq 0 ]
+  grep -q 'commit_type_hint=fix:' "$GITHUB_OUTPUT"
+  grep -q 'branch=fix/issue-42-crash-on-empty-input' "$GITHUB_OUTPUT"
+}
+
+@test "slug strips punctuation, collapses separators, trims trailing dashes" {
+  export STUB_ISSUE_LABELS="type:coding-task"
+  export STUB_ISSUE_TITLE="  Refine: the (refiner) -- stop!  "
+  run derive
+  [ "$status" -eq 0 ]
+  grep -q 'branch=feat/issue-42-refine-the-refiner-stop' "$GITHUB_OUTPUT"
+}
+
+@test "fails when no implementable type label is present" {
+  export STUB_ISSUE_LABELS="type:spike"
+  export STUB_ISSUE_TITLE="Investigate something"
+  run derive
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"neither type:bug nor type:coding-task"* ]]
+}

--- a/.github/workflows/code-pipeline.yml
+++ b/.github/workflows/code-pipeline.yml
@@ -227,6 +227,20 @@ jobs:
           "${{ steps.pr.outputs.head_ref }}"
           "${{ steps.issue.outputs.number }}"
 
+      # Both the Conventional Commit prefix and the branch name are derivable
+      # from the issue's type:* label and title before the agent runs — the
+      # coder shouldn't spend reasoning inventing them. Initial round only; a
+      # fix round reuses the existing PR branch.
+      - name: Derive commit-type and branch hints
+        id: hints
+        if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.fix_round != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: >
+          .interns/.github/scripts/pipeline/derive-code-hints.sh
+          "${{ steps.issue.outputs.number }}"
+
       - name: Run Claude coder (initial implementation)
         id: claude_initial
         if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.fix_round != 'true'
@@ -244,6 +258,8 @@ jobs:
             ISSUE NUMBER: ${{ steps.issue.outputs.number }}
             TITLE: ${{ steps.issue.outputs.title }}
             OWNER: @${{ github.repository_owner }}
+            COMMIT_TYPE_HINT: ${{ steps.hints.outputs.commit_type_hint }}
+            BRANCH: ${{ steps.hints.outputs.branch }}
             BODY:
             ${{ steps.issue.outputs.body }}
 


### PR DESCRIPTION
## What changed

The coder job now computes two hints before the agent runs and passes them into the initial-round prompt:

- **`COMMIT_TYPE_HINT`** — a Conventional Commit prefix derived from the issue's `type:*` label: `type:bug` → `fix:`, `type:coding-task` → `feat:`.
- **`BRANCH`** — `<prefix>/issue-<n>-<slug>`, where the slug is the issue title lowercased, punctuation collapsed to `-`, and truncated to 40 chars.

New `.github/scripts/pipeline/derive-code-hints.sh` (with bats coverage) does the derivation; a new workflow step runs it and exposes the outputs. It runs after the issue-type gate, so a non-implementable type can't reach it.

`code.md` now:
- tells the agent to use the provided `BRANCH` instead of inventing a `<type>/<short-slug>` (the undefined "short-slug" instruction is gone);
- treats `COMMIT_TYPE_HINT` as the default PR-title prefix, to be overridden only with a one-line justification in the PR body;
- drops the bare "get the type right".

Enforcing the prefix in `open-pr.sh` is left as a follow-up, per the issue.

## Behaviour

Unchanged for a normal `type:coding-task` / `type:bug`: the prefix is still `feat:` / `fix:`, and `push-branch.sh` squashes the branch on push so the branch name stays cosmetic.

Closes #55