### PR TITLE
feat(estimate): deterministic scores-to-size roll-up in code

### DIFF
--- a/.github/prompts/estimate.md
+++ b/.github/prompts/estimate.md
@@ -47,16 +47,12 @@ what you looked for and didn't find:
   one clean review pass is Low; multiple PRs or back-and-forth design
   review is High.
 
-Then roll the four scores into a single SIZE (XS/S/M/L/XL) — a holistic
-call, not a formula. Mostly-Low across the board is XS/S; a mix of Mid is
-M; multiple Highs is L; a High on more than one criterion at once is XL.
-XL is still a coherent, scoped deliverable — if the scope is too large or
-entangled to put a number on, don't force out an XL; see the stop
-conditions below.
+Score the four criteria and stop there — the pipeline maps the tuple to a
+single size deterministically, so there is no SIZE line for you to write or
+reason about.
 
 If you see natural seams where the work could be split, say so in the
-normal reasoning — the "which criterion drove the size" sentence, or the
-REVIEW OVERHEAD / TOUCH reasoning. The owner decides whether to split
+REVIEW OVERHEAD or TOUCH reasoning. The owner decides whether to split
 before approving.
 
 Output exactly this format:
@@ -65,19 +61,8 @@ BLAST RADIUS: <Low|Mid|High> — <one sentence naming the code you read>
 TOUCH: <Low|Mid|High> — <one sentence naming the code you read>
 HUMAN INVOLVEMENT: <Low|Mid|High> — <one sentence naming the code you read>
 REVIEW OVERHEAD: <Low|Mid|High> — <one sentence naming the code you read>
-SIZE: <XS|S|M|L|XL>
-<one sentence on which criterion or criteria drove the size>
 
 Output nothing else — no preamble, no closing remarks.
-
-## Spikes
-
-A `type:spike` is sized the same way — the estimate tells the owner whether
-the investigation is worth their time. A spike's pipeline path ends here: no
-coder picks it up. Add one line above the format block in your comment:
-
-> This is a spike; no coder picks it up. The estimate is for your planning.
-> Do the investigation and close when done.
 
 ## When to stop instead of estimating
 
@@ -87,10 +72,10 @@ specific reason, and report that you stopped, in any of these cases:
 
 1. **Unsizeable ambiguity** — Scope or Acceptance Criteria are genuinely
    unsizeable without knowing which of two very different implementations
-   is intended. Don't force out a size.
+   is intended. Don't force out scores.
 2. **Missing prerequisites** — the ticket depends on something not built or
    not decided yet, so estimating it now is guesswork. Say what's missing
    and that it should be estimated once that lands.
-3. **Too large to size** — the scope is coherent but so big that any single
-   number would be a guess, and it isn't a `type:epic`. Note why, and
+3. **Too large to size** — the scope is coherent but so big that any size
+   would be a guess, and it isn't a `type:epic`. Note why, and
    suggest a breakdown (splitting it, or re-typing it as an epic).

--- a/.github/scripts/pipeline/roll-up-estimate.sh
+++ b/.github/scripts/pipeline/roll-up-estimate.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Estimate-job glue: read the four scores out of the estimator's comment file,
+# roll them into a size with roll-up-size.sh, and apply the labels the agent no
+# longer touches — `size:<SIZE>` plus the status:refined -> status:estimated
+# swap. Keeping the mapping and the label write here (not in the agent) makes
+# the size reproducible from the four scores alone.
+#
+# Usage: roll-up-estimate.sh <comment-file>
+#   Env: ISSUE, GITHUB_REPOSITORY, GH_TOKEN
+
+set -euo pipefail
+
+comment="$1"
+here="$(dirname "${BASH_SOURCE[0]}")"
+
+# Pull "<Low|Mid|High>" from the first line that starts with the criterion
+# label, e.g. "TOUCH: Mid — one file". Case-insensitive label match; the score
+# word itself is handed to roll-up-size.sh, which validates it.
+score() {
+  grep -im1 "^$1:" "$comment" \
+    | sed -E 's/^[^:]*:[[:space:]]*([A-Za-z]+).*/\1/'
+}
+
+blast_radius=$(score "BLAST RADIUS")
+touch=$(score "TOUCH")
+human=$(score "HUMAN INVOLVEMENT")
+review=$(score "REVIEW OVERHEAD")
+
+if [[ -z "$blast_radius" || -z "$touch" || -z "$human" || -z "$review" ]]; then
+  echo "roll-up-estimate.sh: couldn't find all four scores in $comment" >&2
+  exit 1
+fi
+
+size=$("$here/roll-up-size.sh" "$blast_radius" "$touch" "$human" "$review")
+echo "Rolled ($blast_radius, $touch, $human, $review) -> size:$size"
+
+gh issue edit "$ISSUE" --repo "$GITHUB_REPOSITORY" \
+  --remove-label status:refined \
+  --add-label status:estimated \
+  --add-label "size:$size"

--- a/.github/scripts/pipeline/roll-up-size.sh
+++ b/.github/scripts/pipeline/roll-up-size.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Deterministic scores -> SIZE mapping for the estimate job. The estimator
+# outputs only the four Low|Mid|High scores; this script rolls them into one
+# size so the mapping is reproducible and testable instead of a judgement the
+# agent makes and then re-parses from its own prose.
+#
+# The tuple collapses to a (#High, #Mid) key — order between the four criteria
+# doesn't change the size, only how many landed at each level. One explicit
+# lookup table covers every reachable key (#High + #Mid <= 4):
+#
+#   no Highs        -> Low count drives it: all-Low is XS, a couple of Mids S,
+#                      mostly-Mid M
+#   one High        -> M, unless the rest are Mid-heavy (-> L)
+#   two Highs       -> L  (this is the old prose's "multiple Highs")
+#   three+ Highs    -> XL (a High on most criteria at once)
+#
+# Usage: roll-up-size.sh <blast-radius> <touch> <human-involvement> <review-overhead>
+#   each argument Low|Mid|High (case-insensitive); prints XS|S|M|L|XL
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: roll-up-size.sh <blast-radius> <touch> <human-involvement> <review-overhead>" >&2
+  exit 2
+fi
+
+highs=0 mids=0
+for raw in "$@"; do
+  case "${raw,,}" in
+    low)  ;;
+    mid)  mids=$((mids + 1)) ;;
+    high) highs=$((highs + 1)) ;;
+    *) echo "roll-up-size.sh: not a Low|Mid|High score: '$raw'" >&2; exit 2 ;;
+  esac
+done
+
+declare -A SIZE=(
+  [0,0]=XS [0,1]=S  [0,2]=S  [0,3]=M  [0,4]=M
+  [1,0]=M  [1,1]=M  [1,2]=M  [1,3]=L
+  [2,0]=L  [2,1]=L  [2,2]=L
+  [3,0]=XL [3,1]=XL
+  [4,0]=XL
+)
+
+echo "${SIZE[$highs,$mids]}"

--- a/.github/scripts/pipeline/spike-advisory.sh
+++ b/.github/scripts/pipeline/spike-advisory.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Post the spike advisory on a `type:spike` issue after estimation. The estimate
+# is the end of a spike's pipeline path — no coder picks it up — so the owner
+# needs that spelled out. The notice comes from the workflow, not the agent:
+# type:spike is known from the issue's labels before the agent runs, so there's
+# nothing for the agent to decide.
+#
+# No-op on any other issue type.
+#
+# Usage: spike-advisory.sh
+#   Env: ISSUE, GITHUB_REPOSITORY, GH_TOKEN
+
+set -euo pipefail
+
+labels=$(gh issue view "$ISSUE" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")')
+
+if [[ ",$labels," != *",type:spike,"* ]]; then
+  echo "Issue #$ISSUE is not a spike — no advisory."
+  exit 0
+fi
+
+gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body \
+  "This is a spike; no coder picks it up. The estimate above is for your planning — do the investigation and close the issue when done."

--- a/.github/scripts/pipeline/tests/roll-up-estimate.bats
+++ b/.github/scripts/pipeline/tests/roll-up-estimate.bats
@@ -1,0 +1,50 @@
+setup() {
+  load helpers
+  setup_stubs
+  export ISSUE=34
+  COMMENT="$BATS_TEST_TMPDIR/comment.md"
+}
+
+write_comment() { printf '%s\n' "$@" >"$COMMENT"; }
+
+@test "rolls the four scores and applies size + status labels" {
+  write_comment \
+    "BLAST RADIUS: Low — isolated" \
+    "TOUCH: Mid — a couple files" \
+    "HUMAN INVOLVEMENT: Low — none" \
+    "REVIEW OVERHEAD: Mid — one pass"
+  run "$PIPELINE_DIR/roll-up-estimate.sh" "$COMMENT"
+  [ "$status" -eq 0 ]
+  grep -q 'gh issue edit 34 --repo owner/repo --remove-label status:refined --add-label status:estimated --add-label size:S' "$STUB_LOG"
+}
+
+@test "label match is case-insensitive and tolerates extra prose" {
+  write_comment \
+    "blast radius: High — auth" \
+    "Touch: High — many modules" \
+    "HUMAN INVOLVEMENT: High — manual verification everywhere" \
+    "REVIEW OVERHEAD: Mid — a pass or two"
+  run "$PIPELINE_DIR/roll-up-estimate.sh" "$COMMENT"
+  [ "$status" -eq 0 ]
+  grep -q -- '--add-label size:XL' "$STUB_LOG"
+}
+
+@test "a missing score fails without touching labels" {
+  write_comment \
+    "BLAST RADIUS: Low — isolated" \
+    "TOUCH: Low — one file"
+  run "$PIPELINE_DIR/roll-up-estimate.sh" "$COMMENT"
+  [ "$status" -eq 1 ]
+  ! grep -q 'gh issue edit' "$STUB_LOG"
+}
+
+@test "an unparseable score is rejected by roll-up-size" {
+  write_comment \
+    "BLAST RADIUS: Medium — hedged" \
+    "TOUCH: Low — one file" \
+    "HUMAN INVOLVEMENT: Low — none" \
+    "REVIEW OVERHEAD: Low — one pass"
+  run "$PIPELINE_DIR/roll-up-estimate.sh" "$COMMENT"
+  [ "$status" -ne 0 ]
+  ! grep -q 'gh issue edit' "$STUB_LOG"
+}

--- a/.github/scripts/pipeline/tests/roll-up-size.bats
+++ b/.github/scripts/pipeline/tests/roll-up-size.bats
@@ -1,0 +1,58 @@
+setup() {
+  load helpers
+  SCRIPT="$PIPELINE_DIR/roll-up-size.sh"
+}
+
+size() { run "$SCRIPT" "$@"; [ "$status" -eq 0 ]; echo "$output"; }
+
+@test "all Low is XS" {
+  [ "$(size Low Low Low Low)" = XS ]
+}
+
+@test "a Mid or two among Lows is S" {
+  [ "$(size Mid Low Low Low)" = S ]
+  [ "$(size Low Mid Low Mid)" = S ]
+}
+
+@test "mostly-Mid is M" {
+  [ "$(size Mid Mid Mid Low)" = M ]
+  [ "$(size Mid Mid Mid Mid)" = M ]
+}
+
+@test "a single High is M" {
+  [ "$(size High Low Low Low)" = M ]
+  [ "$(size Low Low High Mid)" = M ]
+}
+
+@test "one High plus Mid-heavy rest is L" {
+  [ "$(size High Mid Mid Mid)" = L ]
+}
+
+@test "two Highs is L regardless of the other two (the old 'multiple Highs')" {
+  [ "$(size High High Low Low)" = L ]
+  [ "$(size High High Mid Mid)" = L ]
+}
+
+@test "three or four Highs is XL (High on most criteria at once)" {
+  [ "$(size High High High Low)" = XL ]
+  [ "$(size High High High High)" = XL ]
+}
+
+@test "order of the four scores doesn't change the size" {
+  [ "$(size High Low High Mid)" = "$(size Low Mid High High)" ]
+}
+
+@test "scores are case-insensitive" {
+  [ "$(size low MID high Low)" = "$(size Low Mid High Low)" ]
+}
+
+@test "wrong argument count exits 2" {
+  run "$SCRIPT" Low Low Low
+  [ "$status" -eq 2 ]
+}
+
+@test "an unrecognized score exits 2" {
+  run "$SCRIPT" Low Low Low Enormous
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not a Low|Mid|High score"* ]]
+}

--- a/.github/scripts/pipeline/tests/spike-advisory.bats
+++ b/.github/scripts/pipeline/tests/spike-advisory.bats
@@ -1,0 +1,19 @@
+setup() {
+  load helpers
+  setup_stubs
+  export ISSUE=34
+}
+
+@test "posts the advisory on a type:spike issue" {
+  export STUB_ISSUE_LABELS="type:spike,status:refined"
+  run "$PIPELINE_DIR/spike-advisory.sh"
+  [ "$status" -eq 0 ]
+  grep -q 'gh issue comment 34 --repo owner/repo --body This is a spike; no coder picks it up' "$STUB_LOG"
+}
+
+@test "no-op on any other issue type" {
+  export STUB_ISSUE_LABELS="type:coding-task,status:refined"
+  run "$PIPELINE_DIR/spike-advisory.sh"
+  [ "$status" -eq 0 ]
+  ! grep -q 'gh issue comment' "$STUB_LOG"
+}

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -301,15 +301,32 @@ jobs:
             1. Write the estimate output (verbatim) to
                ./.issue-pipeline-comment.md
             2. Run ./.interns/.github/scripts/gh-safe/comment-issue.sh (no args)
-            3. Add the size label matching your SIZE line (size:XS,
-               size:S, size:M, size:L, or size:XL) and swap status:
-               ./.interns/.github/scripts/gh-safe/edit-issue-labels.sh --remove-label "status:refined" --add-label "status:estimated" --add-label "size:<SIZE>"
-
-            Do nothing else.
+            Then stop. The workflow rolls your four scores into a size and
+            applies the `size:*` and `status:estimated` labels — you don't
+            touch labels on this path.
           claude_args: |
             --model ${{ steps.cfg.outputs.model }}
             --max-turns ${{ steps.cfg.outputs.max_turns }}
             --allowedTools "Read,Grep,Glob,Write,${{ env.ALLOWED_COMMENT }},${{ env.ALLOWED_EDIT_LABELS }}"
+
+      - name: Roll up size and apply labels
+        id: size
+        if: steps.gate.outputs.skip != 'true' && steps.claude.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE: ${{ steps.issue.outputs.number }}
+        run: >
+          .interns/.github/scripts/pipeline/roll-up-estimate.sh
+          ./.issue-pipeline-comment.md
+
+      - name: Spike advisory
+        if: steps.gate.outputs.skip != 'true' && steps.claude.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE: ${{ steps.issue.outputs.number }}
+        run: .interns/.github/scripts/pipeline/spike-advisory.sh
 
       - name: Report run cost
         if: always() && steps.claude.outputs.execution_file != ''

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Four agents pick issues up by label and hand them along a fixed track:
 | Agent | Trigger                                                               | Does | Leaves |
 |---|-----------------------------------------------------------------------|---|---|
 | **Refiner** | `status:needs-refinement` on an issue                                 | picks the type, checks the draft against the codebase and wiki, rewrites the body into the type's template (and the title if it no longer fits), posts a blockers/dependencies comment | `status:refined` |
-| **Estimator** | `status:refined`                                                      | reads the code the Scope touches, scores blast radius / touch / human involvement / review overhead, rolls that into a size | `status:estimated` + `size:*` |
+| **Estimator** | `status:refined`                                                      | reads the code the Scope touches, scores blast radius / touch / human involvement / review overhead; the pipeline maps those four scores to a size | `status:estimated` + `size:*` |
 | **Coder** | `status:ready` (human-assigned) on a `type:coding-task` or `type:bug` | implements every Acceptance Criteria item, writes tests, opens a PR that `Closes #N` | `status:in-progress`, a PR labelled `pr:in-review` |
 | **Reviewer** | a PR opened/updated by the coder (or a human)                         | waits for the PR's checks to be green, reviews the diff against the linked issue, submits `APPROVE` or `REQUEST_CHANGES` | PR approved, or a coder fix round, or `pr:needs-attention` |
 
@@ -122,7 +122,9 @@ into sub-issues. Either way, a human takes it from there.
 
 ### `size:*` and `priority:*`
 
-`size:XS` … `size:XL` are added by the estimator alongside `status:estimated`.
+`size:XS` … `size:XL` are applied alongside `status:estimated`: the estimator
+scores the four criteria and `roll-up-size.sh` maps that tuple to one size via a
+fixed lookup table, so the size is reproducible from the scores.
 `priority:low` …
 `priority:urgent` are owner triage labels — the pipeline reads neither; they
 exist for humans sorting the backlog.


### PR DESCRIPTION
Closes #53

## What

The estimator's SIZE was a self-parsed judgement: `estimate.md` gave a formula that contradicted itself ("multiple Highs is L" vs "a High on more than one criterion is XL"), the agent picked a size, wrote a `SIZE:` line, then parsed that line back to choose the `size:*` label. This makes the mapping deterministic and testable.

## Changes

- **`.github/scripts/pipeline/roll-up-size.sh`** (new) — pure function: four `Low|Mid|High` scores to `XS|S|M|L|XL` via one explicit lookup table keyed by `(#High, #Mid)`. Order of the criteria doesn't matter. `roll-up-size.bats` covers every bucket plus the overlap cases the old prose got wrong: two Highs to L, three-or-more Highs to XL.
- **`.github/scripts/pipeline/roll-up-estimate.sh`** (new) — estimate-job glue: parse the four scores out of the agent's comment file, call `roll-up-size.sh`, apply `size:<SIZE>` and swap `status:refined` to `status:estimated`. `.bats` included.
- **`.github/scripts/pipeline/spike-advisory.sh`** (new) — the "this is a spike; no coder picks it up" notice, posted by the workflow for `type:spike` issues (known before the agent runs). `.bats` included.
- **`.github/prompts/estimate.md`** — removed the `SIZE:` output line, the scores-to-size formula paragraph, the "which criterion drove the size" sentence, and the entire `## Spikes` block. The agent now outputs only the four scores.
- **`.github/workflows/issue-pipeline.yml`** — the estimate job runs the two new scripts after the Claude step; the agent no longer touches labels on the happy path.
- **`README.md`** — reworded the estimator row and the `size:*` section.

## Acceptance criteria

- [x] `estimate.md` no longer contains a SIZE output line or a scores-to-size formula
- [x] `roll-up-size.sh` exists with a single lookup table and passing `.bats` tests
- [x] The estimate job computes and applies `size:*` from the script, not the agent
- [x] The spike advisory line is added by the workflow for `type:spike` issues
- [x] `estimate.md` no longer contains a "## Spikes" section

## Testing

`bats .github/scripts/pipeline/tests` — 122 pass. `shellcheck -x` and `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
