### PR TITLE
docs(prompts): tighten vague and duplicated wording across agent prompts

### DIFF
--- a/.github/prompts/code-fix.md
+++ b/.github/prompts/code-fix.md
@@ -22,8 +22,8 @@ run `.interns/.github/scripts/gh-safe/comment-pr.sh` (no arguments; the PR
 number is supplied in your environment as `PR_NUMBER`).
 
 Don't modify CI or pipeline configuration — anything under
-`.github/workflows/`, or pipeline scripts the repo marks as protected.
-`push-branch.sh` rejects any push that touches those paths. If addressing
+`.github/workflows/`, or the paths `push-branch.sh` rejects. That script
+rejects any push that touches those paths. If addressing
 the feedback requires such a change, decline the task (see below).
 
 Re-check the repo's own conventions (`CLAUDE.md` / `AGENTS.md`, any
@@ -52,7 +52,10 @@ reviewer for a wasted round. Instead:
 3. Stop without committing or pushing.
 
 The workflow detects the sentinel, sets `status:needs-attention`, and
-escalates to the owner instead of re-running the reviewer.
+escalates to the owner instead of re-running the reviewer. The
+`.coder-gave-up.md` sentinel is the only thing that escalates — a reply
+posted with `comment-pr.sh` alone does not, so it is never a substitute
+for writing the sentinel when you need the owner.
 
 ## Commit and push
 

--- a/.github/prompts/code.md
+++ b/.github/prompts/code.md
@@ -6,12 +6,12 @@ owner comments.
 
 ## Ground yourself first
 
-Read and follow the repo's own agent instructions — `CLAUDE.md`,
-`AGENTS.md`, or whatever equivalent it ships — for tech stack, conventions,
-and any rules on migrations, tests, or commits. If the repo has a
-contributor guide (a `CONTRIBUTING` file, a wiki page), read it for
-branch-naming and PR conventions. If none of that exists, infer the
-conventions from the existing code and match them.
+Read and follow the repo's own agent instructions — `CLAUDE.md` or
+`AGENTS.md` — for tech stack, conventions, and any rules on migrations,
+tests, or commits. If the repo has a contributor guide (a `CONTRIBUTING`
+file, a wiki page), read it for branch-naming and PR conventions. If none
+of that exists, infer the conventions from the existing code and match
+them.
 
 Read existing code for the patterns this change should follow — reuse
 what's there rather than inventing a new shape.
@@ -31,10 +31,9 @@ speculative abstraction, or refactor code the issue didn't ask you to
 touch.
 
 Don't modify CI or pipeline configuration — anything under
-`.github/workflows/`, or pipeline scripts the repo marks as protected.
-`push-branch.sh` rejects any push that touches those paths. If the issue
-seems to require such a change, stop and comment on the issue instead of
-opening a PR.
+`.github/workflows/`, or the paths `push-branch.sh` rejects. That script
+rejects any push that touches those paths. If the issue seems to require
+such a change, stop and comment on the issue instead of opening a PR.
 
 Tests are your responsibility. Add or update tests for the behaviour you
 change, then run the project's build and test commands and make sure they

--- a/.github/prompts/refine.md
+++ b/.github/prompts/refine.md
@@ -25,10 +25,8 @@ Rules:
 - If it already has `type:epic`, stop and comment (see below) — an epic is
   not refined here.
 - Otherwise, infer the type from the title and body.
-- If it's genuinely ambiguous between two types (not just unclear in
-  detail, but shaped differently enough that the type choice changes what
-  the ticket even asks for), that's the kind of blocking ambiguity covered
-  in the clarification rule below — ask the owner instead of guessing.
+- If the type choice is genuinely ambiguous, that is a blocking ambiguity —
+  take the stop-and-comment path below rather than guessing.
 
 The refined body (Step 3) uses the section structure given for that type
 in `TEMPLATE`, a prompt input — same headings, same order. `TEMPLATE`
@@ -73,9 +71,9 @@ title is vague, mislabeled, or no longer matches what the refined body
 describes, rewrite it into a short, specific summary of the corrected body.
 Leave it untouched if it's already accurate — don't reword a fine title.
 
-The rewritten description must be **concise and specific** — tighter than
-the draft you were given, not longer. Cut restatement, hedging, and
-background the owner already knows. A refined Scope is a short list of
+The rewritten description must be **concise and specific**: the rewritten
+body must not exceed the original body's length. Cut restatement, hedging,
+and background the owner already knows. A refined Scope is a short list of
 concrete changes, each pointing at where it lands.
 
 Rules:
@@ -124,20 +122,21 @@ Three cases justify stopping and commenting on the issue (tagging the owner,
 whose handle is in your instructions), then reporting that you stopped
 instead of editing the body:
 
-1. **Blocking ambiguity** — you cannot fill a section without guessing at a
-   fact only the owner would know: not a missing detail you can flag inline
-   with "Needs owner input:", but two plausible interpretations that lead
-   to genuinely different work.
+1. **Blocking ambiguity** — the draft has two plausible readings that lead
+   to genuinely different work, and you cannot pick between them without
+   guessing at a fact only the owner would know. Not a missing detail you
+   can flag inline with "Needs owner input:". This covers the type choice:
+   if two candidate types would each ask for different work, it is a
+   blocking ambiguity.
 2. **Missing prerequisites** — the work depends on something that doesn't
    exist yet (an unbuilt system, an undecided design, a blocked
    dependency), so scoping it now would be guesswork. Say what's missing
    and that refinement should wait until it lands.
-3. **Epic-sized** — the issue isn't a single deliverable but several
-   separate tickets' worth of work. The line: a large-but-single task is an
-   XL `type:coding-task` (one coherent change, one PR, even if big) — refine
-   it normally. An epic is genuinely several independent deliverables that
-   would each be filed and shipped on their own. If it's an epic, ask the
-   human to label the parent `type:epic` and break it into sub-issues.
+3. **Epic-sized** — an epic is several independently shippable
+   deliverables; a big-but-single change is an XL `type:coding-task` (one
+   coherent change, one PR, even if big) and gets refined normally. If it's
+   an epic, ask the human to label the parent `type:epic` and break it into
+   sub-issues.
 
 For each, comment with one specific, answerable request. In the stop case,
 post only that comment — no separate analysis comment, and don't touch the

--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -1,5 +1,4 @@
-You are reviewing a PR opened by the coder agent (or, occasionally, a
-human).
+You are reviewing a PR opened by the coder agent.
 
 Input: the PR number, the number of the linked issue it implements, and
 this repo's conventions.
@@ -24,8 +23,7 @@ too rather than reviewing off the one issue in isolation.
 
 - **Correctness** — does the code actually do what the linked issue's
   Acceptance Criteria ask for? Read the issue, not just the diff.
-- **Security** — injection, unsafe handling of user input, secrets in code,
-  anything from the OWASP top 10 that applies here.
+- **Security** — injection, unsafe handling of user input, secrets in code.
 - **Conventions** — does it follow the repo's own agent instructions
   (`CLAUDE.md` / `AGENTS.md`) and match the patterns already used elsewhere
   in the codebase, rather than inventing a new shape?


### PR DESCRIPTION
## What

Text-only cleanup of the three looser agent prompts (`refine.md`, `code.md`, `review.md`), plus a small `code-fix.md` clarification. No behaviour change.

### `refine.md`
- The type-ambiguity test is now defined once, in stop-condition 1 ("Blocking ambiguity"), and Step 1 just references the stop-and-comment path.
- Epic-vs-XL collapsed to a single line: an epic is several independently shippable deliverables; a big-but-single change is an XL `type:coding-task`.
- "concise and specific — tighter than the draft, not longer" replaced with a checkable bar: the rewritten body must not exceed the original body's length.

### `code.md`
- Names the convention files (`CLAUDE.md` / `AGENTS.md`) and keeps the "else infer from code" fallback; drops "whatever equivalent it ships".
- "pipeline scripts the repo marks as protected" points at "the paths `push-branch.sh` rejects" (there is no marking mechanism; that script is the enforcement).

### `review.md`
- Drops the "(or, occasionally, a human)" aside and the vague "anything from the OWASP top 10 that applies here" clause.

### `code-fix.md`
- Adds one sentence making explicit that only the `.coder-gave-up.md` sentinel escalates — a bare `comment-pr.sh` reply does not.
- Same protected-paths wording fix as `code.md`, for consistency.

## Notes

- The `estimate.md` item ("a holistic call, not a formula") was already resolved by the deterministic scores->size roll-up (commit 1f40422); that line is no longer present, so no change was needed there.
- The `refine.md` literal-reading rule ("prefer the smaller, more literal reading") is left as-is: it governs interpretation within a type, not the type choice itself, so it is not a restatement of the type-ambiguity test.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)
