### PR TITLE
feat(installer): reuse one GitHub App across consumer repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ re-run either any time to fix drift.
 |---|---|---|
 | 1 | Check (and fix) default-branch protection | An agent could ignore its instructions and push straight to the default branch; protection forces every change through a PR. |
 | 2 | Check (and enable) GitHub Pages | Deploy target for the visibility dashboard ([#6](https://github.com/abi83/interns/issues/6)). |
-| 3 | Mint the two GitHub Apps | Separate coder/reviewer identities, so the reviewer can approve the coder's PRs (`claude[bot]` can't approve its own). |
+| 3 | Mint (or reuse) the two GitHub Apps | Separate coder/reviewer identities, so the reviewer can approve the coder's PRs (`claude[bot]` can't approve its own). Reused as-is on further repos under the same account — see [GitHub Apps](#github-apps). |
 | 4 | Write App secrets/variables + `CLAUDE_CODE_OAUTH_TOKEN` | The workflows need these to authenticate as the Apps and call Claude. |
 | 5 | Hand off to `install.yml` | If no caller for it exists yet, open a one-file PR adding `.github/workflows/install.yml` (a thin wrapper) — merge it and re-run the installer. Once present, dispatch it. |
 | 6 | (`install.yml`) Sync labels | The pipeline routes on `status:*` / `type:*` / `pr:*` and can't run without them. |
@@ -192,6 +192,24 @@ to skip it.
 
 Installing each App on the repo is a manual click — the installer prints the
 links.
+
+**One App, many repos.** A GitHub App is per-account (or per-org); only its
+*installation* and the repo's secrets/variables are per-repo. App names are
+globally unique, so a second consumer repo under the same account must reuse
+the Apps from the first, not mint `interns-coder-2`:
+
+- Pass `--coder-app-id` / `--reviewer-app-id` to run the App step
+  non-interactively against the existing Apps.
+- Without the flags, the installer detects that an App with the default name
+  already exists, prints its settings URL, and asks for the App ID and a PEM
+  private key instead of minting.
+- The App ID is on the App's settings page. For the key you can paste the same
+  PEM the first repo already stores, or click **Generate a private key** — an
+  App holds several keys at once and adding one does not revoke the others, so
+  the first repo keeps working. Client secret and webhook secret are
+  account-wide and need no change.
+- Then install the existing App on the new repo (the installer prints the
+  link) and let it write `INTERNS_*_APP_ID` + `INTERNS_*_APP_PRIVATE_KEY`.
 
 #### Secrets and variables
 

--- a/installer/src/interns_install/apps.py
+++ b/installer/src/interns_install/apps.py
@@ -73,6 +73,14 @@ def settings_new_url(repo_owner: str, is_org: bool) -> str:
     return "https://github.com/settings/apps/new"
 
 
+def settings_app_url(repo_owner: str, is_org: bool, slug: str) -> str:
+    """Settings page of an existing App — where its App ID is shown and a new
+    private key can be generated."""
+    if is_org:
+        return f"https://github.com/organizations/{repo_owner}/settings/apps/{slug}"
+    return f"https://github.com/settings/apps/{slug}"
+
+
 class _Handler(BaseHTTPRequestHandler):
     server_version = "interns-install/0.1"
 

--- a/installer/src/interns_install/cli.py
+++ b/installer/src/interns_install/cli.py
@@ -19,7 +19,14 @@ import time
 import webbrowser
 
 from . import gh, safety
-from .apps import APPS, AppSpec, ManifestServer, build_manifest, settings_new_url
+from .apps import (
+    APPS,
+    AppSpec,
+    ManifestServer,
+    build_manifest,
+    settings_app_url,
+    settings_new_url,
+)
 from .console import Console
 
 WORKFLOW = "install.yml"
@@ -50,6 +57,11 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
                    help="target repo (default: the repo `gh` resolves for the cwd)")
     p.add_argument("--yes", action="store_true",
                    help="assume yes for every prompt (non-interactive)")
+    p.add_argument("--coder-app-id", metavar="ID",
+                   help="reuse the coder App with this ID instead of minting one "
+                        "(the App is account-wide; only its install + secrets are per-repo)")
+    p.add_argument("--reviewer-app-id", metavar="ID",
+                   help="reuse the reviewer App with this ID instead of minting one")
     p.add_argument("--dry-run", action="store_true",
                    help="print every mutation without performing it")
     p.add_argument("--issue-templates", nargs="?", const="true", default="false",
@@ -85,12 +97,88 @@ def _secret_verb(name: str, existing: list[str] | None) -> str:
     return "overwrite" if name in existing else "add"
 
 
+def _use_existing_app(con: Console, repo: gh.Repo, spec: AppSpec,
+                      app_id: str | None, slug: str,
+                      existing_secrets: list[str] | None) -> None:
+    """Reuse an account-wide App: write this repo's App-ID variable and private
+    key secret, and prompt to install it here. Never mints, never reads a key
+    back — the operator pastes a PEM (reused from another repo, or freshly
+    generated on the App's settings page; adding a key does not revoke others).
+    """
+    settings_url = settings_app_url(repo.owner, repo.is_org, slug)
+    have_key = existing_secrets is not None and spec.key_secret in existing_secrets
+
+    if con.dry_run:
+        if app_id is None:
+            con.say(f"App '{spec.default_name}' already exists — {settings_url}")
+        con.mutation(f"set variable {spec.id_var} (existing {spec.key} App)")
+        if not have_key:
+            con.mutation(f"{_secret_verb(spec.key_secret, existing_secrets)} "
+                         f"secret {spec.key_secret} (pasted PEM)")
+        con.note_manual(f"install the existing {spec.key} App on {repo.slug}")
+        return
+
+    if app_id is None:
+        con.say(f"an App named '{spec.default_name}' already exists on this account — "
+                "reusing it, no duplicate minted")
+        con.say(f"its App ID (and 'Generate a private key') is on: {settings_url}")
+        if con.assume_yes:
+            con.note_manual(f"pass --{spec.key}-app-id (from {settings_url}) and set "
+                            f"{spec.key_secret}, then install the App on {repo.slug}")
+            return
+        app_id = con.prompt(f"{spec.id_var} — the numeric App ID (blank to skip):")
+        if not app_id:
+            con.note_manual(f"set {spec.id_var} / {spec.key_secret} for the existing "
+                            f"{spec.key} App, then install it on {repo.slug}")
+            return
+    else:
+        con.say(f"reusing {spec.key} App {app_id} — {settings_url}")
+
+    if con.mutation(f"set variable {spec.id_var} = {app_id}"):
+        gh.set_variable(repo.slug, spec.id_var, app_id)
+
+    if have_key:
+        con.say(f"{spec.key_secret} is already set — leaving it (its key stays valid; "
+                "keys held by other repos are unaffected)")
+    elif con.assume_yes:
+        con.note_manual(f"set the {spec.key_secret} secret (a PEM private key for "
+                        f"'{spec.default_name}')")
+    else:
+        pem = con.prompt_secret(
+            f"Paste a PEM private key for '{spec.default_name}' — reuse another "
+            "repo's or generate a new one (blank to skip):")
+        if pem and con.mutation(
+                f"{_secret_verb(spec.key_secret, existing_secrets)} secret {spec.key_secret}"):
+            gh.set_secret(repo.slug, spec.key_secret, pem)
+        elif not pem:
+            con.note_manual(f"set the {spec.key_secret} secret (PEM private key)")
+        pem = None  # noqa: F841 - drop the only reference to the key
+
+    con.note_manual(
+        f"confirm the {spec.key} App is installed on {repo.slug}: "
+        f"https://github.com/apps/{slug}/installations/new"
+    )
+
+
 def _provision_app(con: Console, repo: gh.Repo, spec: AppSpec,
+                   app_id: str | None,
                    existing_secrets: list[str] | None,
                    existing_vars: list[str] | None) -> None:
     con.step(f"GitHub App: {spec.default_name} ({spec.key})")
-    if not con.confirm(f"Create the App '{spec.default_name}' now?", default=True):
+
+    if app_id is not None:
+        con.say(f"--{spec.key}-app-id given — reusing App {app_id}, skipping the mint")
+        _use_existing_app(con, repo, spec, app_id, spec.default_name, existing_secrets)
+        return
+
+    if not con.confirm(f"Set up the App '{spec.default_name}' now?", default=True):
         con.note_manual(f"create the {spec.key} App and set {spec.id_var} / {spec.key_secret}")
+        return
+
+    existing = gh.app_public(spec.default_name)
+    if existing:
+        _use_existing_app(con, repo, spec, None,
+                          existing.get("slug", spec.default_name), existing_secrets)
         return
 
     action_url = settings_new_url(repo.owner, repo.is_org)
@@ -105,7 +193,7 @@ def _provision_app(con: Console, repo: gh.Repo, spec: AppSpec,
     with ManifestServer(action_url, lambda redirect: build_manifest(
         spec.default_name, redirect, spec.description)) as server:
         con.say(f"opening your browser to create '{spec.default_name}' — "
-                "click 'Create GitHub App' (rename it first if that name is taken)")
+                "click 'Create GitHub App'")
         con.say(f"if nothing opened, visit: {server.base_url}")
         webbrowser.open(server.base_url)
         code = server.wait_for_code()
@@ -224,8 +312,10 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     try:
+        app_ids = {"coder": args.coder_app_id, "reviewer": args.reviewer_app_id}
         for spec in APPS:
-            _provision_app(con, repo, spec, existing_secrets, existing_vars)
+            _provision_app(con, repo, spec, app_ids.get(spec.key),
+                           existing_secrets, existing_vars)
         _write_oauth_token(con, repo, existing_secrets)
         if not args.skip_handoff:
             _handoff(con, repo, args)

--- a/installer/src/interns_install/gh.py
+++ b/installer/src/interns_install/gh.py
@@ -126,6 +126,15 @@ def set_variable(repo: str, name: str, value: str) -> None:
     _run(["variable", "set", name, "--repo", repo, "--body", "-"], input_text=value)
 
 
+def app_public(slug: str) -> dict | None:
+    """Public metadata for the App registered under this slug, or None if no
+    such App exists. App names are globally unique, so a hit on the default
+    name means minting it again would collide — reuse the existing App instead.
+    """
+    status, body = api_status(f"apps/{slug}")
+    return body if status == "ok" and isinstance(body, dict) else None
+
+
 def convert_manifest(code: str) -> dict:
     data = api(f"app-manifest/{code}/conversions", method="POST")
     if not isinstance(data, dict) or "pem" not in data:

--- a/installer/tests/test_cli.py
+++ b/installer/tests/test_cli.py
@@ -2,7 +2,14 @@ import unittest
 from unittest import mock
 
 from interns_install import cli, gh
-from interns_install.cli import _add_wrapper, _parse_args, _secret_verb
+from interns_install.apps import APPS
+from interns_install.cli import (
+    _add_wrapper,
+    _parse_args,
+    _provision_app,
+    _secret_verb,
+    _use_existing_app,
+)
 from interns_install.console import Console
 
 
@@ -40,6 +47,63 @@ class ScopeParseTests(unittest.TestCase):
 
     def test_no_scopes_line(self):
         self.assertEqual(gh._parse_scopes("Logged in to github.com"), set())
+
+
+CODER = next(s for s in APPS if s.key == "coder")
+
+
+def _repo():
+    return gh.Repo(owner="acme", name="widgets", is_org=False)
+
+
+class AppIdArgTests(unittest.TestCase):
+    def test_app_id_flags_parse(self):
+        a = _parse_args(["--coder-app-id", "111", "--reviewer-app-id", "222"])
+        self.assertEqual(a.coder_app_id, "111")
+        self.assertEqual(a.reviewer_app_id, "222")
+
+    def test_app_id_flags_default_none(self):
+        a = _parse_args([])
+        self.assertIsNone(a.coder_app_id)
+        self.assertIsNone(a.reviewer_app_id)
+
+
+class ReuseAppTests(unittest.TestCase):
+    def test_flag_writes_variable_and_keeps_existing_key(self):
+        con = Console(assume_yes=True)
+        with mock.patch.multiple(cli.gh, set_variable=mock.DEFAULT,
+                                 set_secret=mock.DEFAULT) as m:
+            _use_existing_app(con, _repo(), CODER, "12345", "interns-coder",
+                              existing_secrets=[CODER.key_secret])
+        m["set_variable"].assert_called_once_with("acme/widgets", CODER.id_var, "12345")
+        m["set_secret"].assert_not_called()
+        self.assertTrue(any("installed on acme/widgets" in n for n in con.manual))
+
+    def test_flag_without_key_records_manual_under_yes(self):
+        con = Console(assume_yes=True)
+        with mock.patch.multiple(cli.gh, set_variable=mock.DEFAULT,
+                                 set_secret=mock.DEFAULT) as m:
+            _use_existing_app(con, _repo(), CODER, "12345", "interns-coder",
+                              existing_secrets=[])
+        m["set_variable"].assert_called_once()
+        m["set_secret"].assert_not_called()
+        self.assertTrue(any(CODER.key_secret in n for n in con.manual))
+
+    def test_provision_discovers_existing_app_and_skips_mint(self):
+        con = Console(assume_yes=True)
+        with mock.patch.object(cli.gh, "app_public", return_value={"slug": "interns-coder"}), \
+             mock.patch.object(cli, "ManifestServer") as server, \
+             mock.patch.multiple(cli.gh, set_variable=mock.DEFAULT, set_secret=mock.DEFAULT):
+            _provision_app(con, _repo(), CODER, None,
+                           existing_secrets=[CODER.key_secret], existing_vars=[])
+        server.assert_not_called()
+
+    def test_provision_mints_when_no_existing_app(self):
+        con = Console(assume_yes=True, dry_run=True)
+        with mock.patch.object(cli.gh, "app_public", return_value=None):
+            _provision_app(con, _repo(), CODER, None,
+                           existing_secrets=[], existing_vars=[])
+        self.assertTrue(any("via manifest" in p for p in con.planned))
 
 
 class AddWrapperTests(unittest.TestCase):


### PR DESCRIPTION
Closes #65.

## Problem

`interns-install` on a second consumer repo under an account that already owns
`interns-coder` / `interns-reviewer` collided on the globally-unique App name.
The CLI only suggested "rename it first", which produced duplicate Apps and a
separate private key per repo — when the App is meant to be one shared identity.

## Change

- `--coder-app-id` / `--reviewer-app-id` — run the App step non-interactively
  against an existing App: write `INTERNS_*_APP_ID`, keep an already-set
  private-key secret (or note it as manual under `--yes`), and prompt to
  install the App on the target repo.
- Auto-detect — without the flags, `gh.app_public()` checks whether an App with
  the default name already exists (`GET /apps/{slug}`). If so, the installer
  prints its settings URL and prompts for the App ID plus a pasted PEM instead
  of minting a duplicate. The operator can reuse another repo's PEM or generate
  a fresh key (adding a key doesn't revoke the others).
- Fresh mint stays the default when no App exists and no flag is set.
- README: new "One App, many repos" subsection; step-3 row and Apps section
  updated.

## Tests

New `test_cli.py` cases: flag parsing, reuse writes the variable and keeps an
existing key, `--yes` without a key records a manual follow-up, discovery skips
the mint, and mint still runs when no App exists. `PYTHONPATH=src python -m
unittest discover -s tests` — 23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
