### PR TITLE
feat(installer): prefill existing App ID from public metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,13 +201,13 @@ the Apps from the first, not mint `interns-coder-2`:
 - Pass `--coder-app-id` / `--reviewer-app-id` to run the App step
   non-interactively against the existing Apps.
 - Without the flags, the installer detects that an App with the default name
-  already exists, prints its settings URL, and asks for the App ID and a PEM
-  private key instead of minting.
-- The App ID is on the App's settings page. For the key you can paste the same
-  PEM the first repo already stores, or click **Generate a private key** — an
-  App holds several keys at once and adding one does not revoke the others, so
-  the first repo keeps working. Client secret and webhook secret are
-  account-wide and need no change.
+  already exists, reads its App ID from the App's public metadata, and asks
+  only for a PEM private key instead of minting. If that lookup can't return
+  the ID, it prints the settings URL and asks for it too.
+- For the key you can paste the same PEM the first repo already stores, or
+  click **Generate a private key** — an App holds several keys at once and
+  adding one does not revoke the others, so the first repo keeps working.
+  Client secret and webhook secret are account-wide and need no change.
 - Then install the existing App on the new repo (the installer prints the
   link) and let it write `INTERNS_*_APP_ID` + `INTERNS_*_APP_PRIVATE_KEY`.
 

--- a/installer/src/interns_install/cli.py
+++ b/installer/src/interns_install/cli.py
@@ -109,8 +109,7 @@ def _use_existing_app(con: Console, repo: gh.Repo, spec: AppSpec,
     have_key = existing_secrets is not None and spec.key_secret in existing_secrets
 
     if con.dry_run:
-        if app_id is None:
-            con.say(f"App '{spec.default_name}' already exists — {settings_url}")
+        con.say(f"existing {spec.key} App — {settings_url}")
         con.mutation(f"set variable {spec.id_var} (existing {spec.key} App)")
         if not have_key:
             con.mutation(f"{_secret_verb(spec.key_secret, existing_secrets)} "
@@ -119,8 +118,6 @@ def _use_existing_app(con: Console, repo: gh.Repo, spec: AppSpec,
         return
 
     if app_id is None:
-        con.say(f"an App named '{spec.default_name}' already exists on this account — "
-                "reusing it, no duplicate minted")
         con.say(f"its App ID (and 'Generate a private key') is on: {settings_url}")
         if con.assume_yes:
             con.note_manual(f"pass --{spec.key}-app-id (from {settings_url}) and set "
@@ -177,7 +174,11 @@ def _provision_app(con: Console, repo: gh.Repo, spec: AppSpec,
 
     existing = gh.app_public(spec.default_name)
     if existing:
-        _use_existing_app(con, repo, spec, None,
+        con.say(f"an App named '{spec.default_name}' already exists on this account — "
+                "reusing it, no duplicate minted")
+        discovered_id = existing.get("id")
+        _use_existing_app(con, repo, spec,
+                          str(discovered_id) if discovered_id else None,
                           existing.get("slug", spec.default_name), existing_secrets)
         return
 

--- a/installer/tests/test_cli.py
+++ b/installer/tests/test_cli.py
@@ -98,6 +98,17 @@ class ReuseAppTests(unittest.TestCase):
                            existing_secrets=[CODER.key_secret], existing_vars=[])
         server.assert_not_called()
 
+    def test_provision_prefills_app_id_from_public_metadata(self):
+        con = Console(assume_yes=True)
+        with mock.patch.object(cli.gh, "app_public",
+                               return_value={"slug": "interns-coder", "id": 987654}), \
+             mock.patch.object(cli, "ManifestServer") as server, \
+             mock.patch.multiple(cli.gh, set_variable=mock.DEFAULT, set_secret=mock.DEFAULT) as m:
+            _provision_app(con, _repo(), CODER, None,
+                           existing_secrets=[CODER.key_secret], existing_vars=[])
+        server.assert_not_called()
+        m["set_variable"].assert_called_once_with("acme/widgets", CODER.id_var, "987654")
+
     def test_provision_mints_when_no_existing_app(self):
         con = Console(assume_yes=True, dry_run=True)
         with mock.patch.object(cli.gh, "app_public", return_value=None):


### PR DESCRIPTION
## What

When the installer reuses an account-wide App (second consumer repo under the
same account), it now reads the numeric App ID from the `GET /apps/{slug}`
response — the same call it already makes to detect the collision — instead of
asking the operator to copy it from the settings page. The operator is only
prompted for a PEM private key.

If the lookup somehow returns no `id`, it falls back to printing the settings
URL and prompting, so nothing regresses.

## Why

Follow-up to #66 (which closed #65). The public App metadata already carries
`id`; prompting for it was an avoidable papercut in the reuse path.

## Changes

- `_provision_app`: pass the discovered `id` through to `_use_existing_app`.
- `_use_existing_app`: tidy the now-redundant "already exists" messaging and
  the dry-run branch.
- README: reflect that the App ID is auto-detected.
- Test: `test_provision_prefills_app_id_from_public_metadata`.

`installer` test suite: 24 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
