### PR TITLE
fix(installer): namespace minted App names per account

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,10 @@ to skip it.
 
 #### GitHub Apps
 
-`interns-coder` and `interns-reviewer`, minted via the App Manifest flow, one
-"Create GitHub App" click each. Same permission set, no webhook:
+`interns-coder-<owner>` and `interns-reviewer-<owner>`, minted via the App
+Manifest flow, one "Create GitHub App" click each. GitHub App names are globally
+unique, so the minted name carries the owning account. Same permission set, no
+webhook:
 
 | Permission | Access | Why |
 |---|---|---|
@@ -194,16 +196,16 @@ Installing each App on the repo is a manual click — the installer prints the
 links.
 
 **One App, many repos.** A GitHub App is per-account (or per-org); only its
-*installation* and the repo's secrets/variables are per-repo. App names are
-globally unique, so a second consumer repo under the same account must reuse
-the Apps from the first, not mint `interns-coder-2`:
+*installation* and the repo's secrets/variables are per-repo. A second consumer
+repo under the same account reuses that account's `interns-*-<owner>` pair
+rather than minting a duplicate:
 
 - Pass `--coder-app-id` / `--reviewer-app-id` to run the App step
   non-interactively against the existing Apps.
-- Without the flags, the installer detects that an App with the default name
-  already exists, reads its App ID from the App's public metadata, and asks
-  only for a PEM private key instead of minting. If that lookup can't return
-  the ID, it prints the settings URL and asks for it too.
+- Without the flags, the installer looks up `interns-<role>-<owner>`, confirms
+  the account owns it, reads its App ID from the App's public metadata, and
+  asks only for a PEM private key instead of minting. If that lookup can't
+  return the ID, it prints the settings URL and asks for it too.
 - For the key you can paste the same PEM the first repo already stores, or
   click **Generate a private key** — an App holds several keys at once and
   adding one does not revoke the others, so the first repo keeps working.
@@ -220,10 +222,10 @@ installer prompts you to paste a token you obtain separately (see
 | Kind | Name | Value |
 |---|---|---|
 | Secret | `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token for `anthropics/claude-code-action` |
-| Secret | `INTERNS_CODER_APP_PRIVATE_KEY` | `interns-coder` private key (PEM) |
-| Secret | `INTERNS_REVIEWER_APP_PRIVATE_KEY` | `interns-reviewer` private key (PEM) |
-| Variable | `INTERNS_CODER_APP_ID` | `interns-coder` App ID |
-| Variable | `INTERNS_REVIEWER_APP_ID` | `interns-reviewer` App ID |
+| Secret | `INTERNS_CODER_APP_PRIVATE_KEY` | coder App private key (PEM) |
+| Secret | `INTERNS_REVIEWER_APP_PRIVATE_KEY` | reviewer App private key (PEM) |
+| Variable | `INTERNS_CODER_APP_ID` | coder App ID |
+| Variable | `INTERNS_REVIEWER_APP_ID` | reviewer App ID |
 
 The `install.yml` safety check fails the install if a required secret or
 variable is missing; if its token can't list them it warns and leaves

--- a/installer/src/interns_install/apps.py
+++ b/installer/src/interns_install/apps.py
@@ -31,23 +31,29 @@ APP_PERMISSIONS = {
 @dataclass
 class AppSpec:
     key: str            # "reviewer" / "coder"
-    default_name: str   # "interns-reviewer" / "interns-coder"
+    name_base: str      # "interns-reviewer" / "interns-coder"
     id_var: str         # "INTERNS_REVIEWER_APP_ID"
     key_secret: str     # "INTERNS_REVIEWER_APP_PRIVATE_KEY"
     description: str
+
+    def name_for(self, owner: str) -> str:
+        """GitHub App names are globally unique, so the minted name carries the
+        owning account: two accounts each get their own `interns-<role>-<acct>`
+        instead of racing for one global `interns-<role>`."""
+        return f"{self.name_base}-{owner.lower()}"
 
 
 APPS = [
     AppSpec(
         key="reviewer",
-        default_name="interns-reviewer",
+        name_base="interns-reviewer",
         id_var="INTERNS_REVIEWER_APP_ID",
         key_secret="INTERNS_REVIEWER_APP_PRIVATE_KEY",
         description="submits PR reviews for the interns pipeline (claude[bot] can't approve its own PR)",
     ),
     AppSpec(
         key="coder",
-        default_name="interns-coder",
+        name_base="interns-coder",
         id_var="INTERNS_CODER_APP_ID",
         key_secret="INTERNS_CODER_APP_PRIVATE_KEY",
         description="coder-side pushes, PRs, comments and label edits for the interns pipeline",

--- a/installer/src/interns_install/cli.py
+++ b/installer/src/interns_install/cli.py
@@ -97,6 +97,13 @@ def _secret_verb(name: str, existing: list[str] | None) -> str:
     return "overwrite" if name in existing else "add"
 
 
+def _app_owner(app: dict) -> str:
+    """Login of the account that owns a `GET /apps/{slug}` result, lowercased.
+    A same-name App owned by someone else is a global-namespace collision, not
+    something this account can reuse."""
+    return str((app.get("owner") or {}).get("login", "")).lower()
+
+
 def _use_existing_app(con: Console, repo: gh.Repo, spec: AppSpec,
                       app_id: str | None, slug: str,
                       existing_secrets: list[str] | None) -> None:
@@ -139,11 +146,13 @@ def _use_existing_app(con: Console, repo: gh.Repo, spec: AppSpec,
                 "keys held by other repos are unaffected)")
     elif con.assume_yes:
         con.note_manual(f"set the {spec.key_secret} secret (a PEM private key for "
-                        f"'{spec.default_name}')")
+                        f"'{slug}')")
     else:
         pem = con.prompt_secret(
-            f"Paste a PEM private key for '{spec.default_name}' — reuse another "
-            "repo's or generate a new one (blank to skip):")
+            f"Paste a private key (PEM) for the '{slug}' App. This repo needs its "
+            f"own copy in {spec.key_secret}; GitHub Actions secrets aren't shared "
+            f"between repos. Reuse a .pem you saved for another repo, or generate "
+            f"one at {settings_url}. Blank to set the secret yourself later:")
         if pem and con.mutation(
                 f"{_secret_verb(spec.key_secret, existing_secrets)} secret {spec.key_secret}"):
             gh.set_secret(repo.slug, spec.key_secret, pem)
@@ -161,39 +170,42 @@ def _provision_app(con: Console, repo: gh.Repo, spec: AppSpec,
                    app_id: str | None,
                    existing_secrets: list[str] | None,
                    existing_vars: list[str] | None) -> None:
-    con.step(f"GitHub App: {spec.default_name} ({spec.key})")
+    name = spec.name_for(repo.owner)
+    con.step(f"GitHub App: {name} ({spec.key})")
 
     if app_id is not None:
         con.say(f"--{spec.key}-app-id given — reusing App {app_id}, skipping the mint")
-        _use_existing_app(con, repo, spec, app_id, spec.default_name, existing_secrets)
+        _use_existing_app(con, repo, spec, app_id, name, existing_secrets)
         return
 
-    if not con.confirm(f"Set up the App '{spec.default_name}' now?", default=True):
+    if not con.confirm(f"Set up the App '{name}' now?", default=True):
         con.note_manual(f"create the {spec.key} App and set {spec.id_var} / {spec.key_secret}")
         return
 
-    existing = gh.app_public(spec.default_name)
-    if existing:
-        con.say(f"an App named '{spec.default_name}' already exists on this account — "
-                "reusing it, no duplicate minted")
+    existing = gh.app_public(name)
+    if existing and _app_owner(existing) == repo.owner.lower():
+        con.say(f"you already own an App named '{name}' — reusing it, no duplicate minted")
         discovered_id = existing.get("id")
         _use_existing_app(con, repo, spec,
                           str(discovered_id) if discovered_id else None,
-                          existing.get("slug", spec.default_name), existing_secrets)
+                          existing.get("slug", name), existing_secrets)
         return
+    if existing:
+        con.say(f"the name '{name}' is held by another account — GitHub will ask "
+                "you to pick a different name in the form")
 
     action_url = settings_new_url(repo.owner, repo.is_org)
 
     if con.dry_run:
-        con.mutation(f"open {action_url} to create App '{spec.default_name}' via manifest")
+        con.mutation(f"open {action_url} to create App '{name}' via manifest")
         con.mutation(f"{_secret_verb(spec.key_secret, existing_secrets)} secret {spec.key_secret}")
         con.mutation(f"set variable {spec.id_var}")
         con.note_manual(f"install the {spec.key} App on {repo.slug}")
         return
 
     with ManifestServer(action_url, lambda redirect: build_manifest(
-        spec.default_name, redirect, spec.description)) as server:
-        con.say(f"opening your browser to create '{spec.default_name}' — "
+        name, redirect, spec.description)) as server:
+        con.say(f"opening your browser to create '{name}' — "
                 "click 'Create GitHub App'")
         con.say(f"if nothing opened, visit: {server.base_url}")
         webbrowser.open(server.base_url)
@@ -201,7 +213,7 @@ def _provision_app(con: Console, repo: gh.Repo, spec: AppSpec,
 
     conv = gh.convert_manifest(code)
     app_id = str(conv["id"])
-    slug = conv.get("slug", spec.default_name)
+    slug = conv.get("slug", name)
     pem = conv["pem"]
 
     # Resilient ordering: the private key is returned exactly once, so it goes

--- a/installer/tests/test_cli.py
+++ b/installer/tests/test_cli.py
@@ -89,25 +89,30 @@ class ReuseAppTests(unittest.TestCase):
         m["set_secret"].assert_not_called()
         self.assertTrue(any(CODER.key_secret in n for n in con.manual))
 
-    def test_provision_discovers_existing_app_and_skips_mint(self):
-        con = Console(assume_yes=True)
-        with mock.patch.object(cli.gh, "app_public", return_value={"slug": "interns-coder"}), \
-             mock.patch.object(cli, "ManifestServer") as server, \
-             mock.patch.multiple(cli.gh, set_variable=mock.DEFAULT, set_secret=mock.DEFAULT):
-            _provision_app(con, _repo(), CODER, None,
-                           existing_secrets=[CODER.key_secret], existing_vars=[])
-        server.assert_not_called()
+    def test_minted_name_is_namespaced_per_owner(self):
+        self.assertEqual(CODER.name_for("Acme"), "interns-coder-acme")
 
-    def test_provision_prefills_app_id_from_public_metadata(self):
+    def test_provision_reuses_own_app_and_prefills_id(self):
         con = Console(assume_yes=True)
-        with mock.patch.object(cli.gh, "app_public",
-                               return_value={"slug": "interns-coder", "id": 987654}), \
+        owned = {"slug": "interns-coder-acme", "id": 987654,
+                 "owner": {"login": "acme"}}
+        with mock.patch.object(cli.gh, "app_public", return_value=owned), \
              mock.patch.object(cli, "ManifestServer") as server, \
              mock.patch.multiple(cli.gh, set_variable=mock.DEFAULT, set_secret=mock.DEFAULT) as m:
             _provision_app(con, _repo(), CODER, None,
                            existing_secrets=[CODER.key_secret], existing_vars=[])
         server.assert_not_called()
         m["set_variable"].assert_called_once_with("acme/widgets", CODER.id_var, "987654")
+
+    def test_provision_mints_when_same_name_owned_by_someone_else(self):
+        con = Console(assume_yes=True, dry_run=True)
+        stranger = {"slug": "interns-coder-acme", "id": 4701402,
+                    "owner": {"login": "jpdlr"}}
+        with mock.patch.object(cli.gh, "app_public", return_value=stranger):
+            _provision_app(con, _repo(), CODER, None,
+                           existing_secrets=[], existing_vars=[])
+        self.assertTrue(any("via manifest" in p for p in con.planned))
+        self.assertFalse(any(str(4701402) in p for p in con.planned))
 
     def test_provision_mints_when_no_existing_app(self):
         con = Console(assume_yes=True, dry_run=True)


### PR DESCRIPTION
Fixes #68.

## Problem

GitHub App names are globally unique across all of GitHub. The installer minted
hardcoded `interns-coder` / `interns-reviewer`, so it worked exactly once across
the entire platform — the first account to run it claimed those names for
everyone. Every later account hits the collision.

Hit in practice: on a fresh account `GET /apps/interns-reviewer` already
resolves to App ID `4701402`, owner `jpdlr` (an unrelated user). The reuse
check added in #66 only asked "does an App with this slug exist?", not "do I
own it?", so it wrote `INTERNS_REVIEWER_APP_ID = 4701402` — a stranger's App —
and then prompted for a private key the operator can't have.

The `claude` App isn't a counterexample: Anthropic operates it centrally, one
key on their servers, never distributed. interns has no such service, so each
consumer account needs its own App — which means the name can't be a global
constant.

## Change

- **Namespace the minted name:** `interns-<role>-<owner>` (e.g.
  `interns-coder-abi83`). Each account mints its own pair, no cross-account
  collision. `AppSpec.name_for(owner)`.
- **Ownership check in the reuse path:** only reuse when `app.owner.login`
  matches the target account; otherwise fall through to mint. New `_app_owner`
  helper.
- **Reworded PEM prompt** — explains that Actions secrets are per-repo, what
  "reuse" and "generate" mean, and where.
- Same-account second repo still reuses cleanly (namespaced name matches, owner
  check passes, existing ID + secret reused).
- `--coder-app-id` / `--reviewer-app-id` unchanged — still the override for an
  already-owned App under any name.
- README updated.

## Tests

`installer` suite: 25 passing (unittest + pytest). New cases: per-owner naming,
reuse-your-own-app + ID prefill, mint-when-name-owned-by-someone-else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
