### PR TITLE
fix(installer): exchange the manifest code unauthenticated

### DIFF
--- a/installer/src/interns_install/gh.py
+++ b/installer/src/interns_install/gh.py
@@ -10,6 +10,8 @@ import base64
 import json
 import shutil
 import subprocess
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 
 
@@ -136,7 +138,27 @@ def app_public(slug: str) -> dict | None:
 
 
 def convert_manifest(code: str) -> dict:
-    data = api(f"app-manifest/{code}/conversions", method="POST")
+    """Exchange the one-time manifest code for the App's credentials.
+
+    Unauthenticated on purpose: GitHub scopes the code to the browser session
+    that submitted the manifest, and sending an `Authorization` header makes
+    this endpoint 404 even when the token's user is that same account.
+    """
+    req = urllib.request.Request(
+        f"https://api.github.com/app-manifest/{code}/conversions",
+        method="POST",
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as exc:
+        raise GhError(
+            f"manifest conversion failed (HTTP {exc.code}) — the code is single-use "
+            "and expires after an hour; re-run to create the App again"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise GhError(f"manifest conversion request failed: {exc.reason}") from exc
     if not isinstance(data, dict) or "pem" not in data:
         raise GhError("manifest conversion did not return a private key")
     return data

--- a/installer/tests/test_apps.py
+++ b/installer/tests/test_apps.py
@@ -1,7 +1,10 @@
+import io
 import unittest
 import urllib.error
 import urllib.request
+from unittest import mock
 
+from interns_install import gh
 from interns_install.apps import (
     APP_PERMISSIONS,
     ManifestServer,
@@ -54,6 +57,33 @@ class ManifestServerTests(unittest.TestCase):
             self.assertEqual(ctx.exception.code, 400)
             with self.assertRaises(TimeoutError):
                 server.wait_for_code(timeout=1)
+
+
+class ConvertManifestTests(unittest.TestCase):
+    def test_exchanges_code_without_authorization_header(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["headers"] = req.headers
+            captured["method"] = req.get_method()
+            captured["url"] = req.full_url
+            return io.BytesIO(b'{"id": 42, "pem": "-----KEY-----", "slug": "x"}')
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            out = gh.convert_manifest("tok123")
+
+        self.assertEqual(out["id"], 42)
+        self.assertEqual(captured["method"], "POST")
+        self.assertIn("app-manifest/tok123/conversions", captured["url"])
+        self.assertNotIn("Authorization", captured["headers"])
+
+    def test_http_error_becomes_ghError(self):
+        def boom(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, None)
+
+        with mock.patch("urllib.request.urlopen", boom), \
+             self.assertRaises(gh.GhError):
+            gh.convert_manifest("expired")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #70.

## Problem

The App Manifest step 404s at the final code exchange (`POST /app-manifest/{code}/conversions`), even with the browser and `gh` CLI on the same account. No App gets created.

GitHub scopes the one-time manifest code to the browser session that submitted the manifest. `gh api` always sends `Authorization`, and presenting a token on that endpoint makes it 404 — which is why create-probot-app / Octokit exchange the code with no auth.

## Change

- `gh.convert_manifest` now POSTs via stdlib `urllib.request`, `Accept: application/vnd.github+json`, **no `Authorization`**.
- Everything else in the installer stays on `gh`.
- A failed exchange (expired / already-used code) raises a clear "re-run to create the App again" message instead of a raw `gh` 404.

## Tests

`installer` suite: 27 passing. New: exchange carries no auth header + parses the response; HTTPError maps to `GhError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
