### PR TITLE
Revert "fix(installer): exchange the manifest code unauthenticated"

### DIFF
--- a/installer/src/interns_install/gh.py
+++ b/installer/src/interns_install/gh.py
@@ -10,8 +10,6 @@ import base64
 import json
 import shutil
 import subprocess
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 
 
@@ -138,27 +136,7 @@ def app_public(slug: str) -> dict | None:
 
 
 def convert_manifest(code: str) -> dict:
-    """Exchange the one-time manifest code for the App's credentials.
-
-    Unauthenticated on purpose: GitHub scopes the code to the browser session
-    that submitted the manifest, and sending an `Authorization` header makes
-    this endpoint 404 even when the token's user is that same account.
-    """
-    req = urllib.request.Request(
-        f"https://api.github.com/app-manifest/{code}/conversions",
-        method="POST",
-        headers={"Accept": "application/vnd.github+json"},
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.loads(resp.read() or b"{}")
-    except urllib.error.HTTPError as exc:
-        raise GhError(
-            f"manifest conversion failed (HTTP {exc.code}) — the code is single-use "
-            "and expires after an hour; re-run to create the App again"
-        ) from exc
-    except urllib.error.URLError as exc:
-        raise GhError(f"manifest conversion request failed: {exc.reason}") from exc
+    data = api(f"app-manifest/{code}/conversions", method="POST")
     if not isinstance(data, dict) or "pem" not in data:
         raise GhError("manifest conversion did not return a private key")
     return data

--- a/installer/tests/test_apps.py
+++ b/installer/tests/test_apps.py
@@ -1,10 +1,7 @@
-import io
 import unittest
 import urllib.error
 import urllib.request
-from unittest import mock
 
-from interns_install import gh
 from interns_install.apps import (
     APP_PERMISSIONS,
     ManifestServer,
@@ -57,33 +54,6 @@ class ManifestServerTests(unittest.TestCase):
             self.assertEqual(ctx.exception.code, 400)
             with self.assertRaises(TimeoutError):
                 server.wait_for_code(timeout=1)
-
-
-class ConvertManifestTests(unittest.TestCase):
-    def test_exchanges_code_without_authorization_header(self):
-        captured = {}
-
-        def fake_urlopen(req, timeout=None):
-            captured["headers"] = req.headers
-            captured["method"] = req.get_method()
-            captured["url"] = req.full_url
-            return io.BytesIO(b'{"id": 42, "pem": "-----KEY-----", "slug": "x"}')
-
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
-            out = gh.convert_manifest("tok123")
-
-        self.assertEqual(out["id"], 42)
-        self.assertEqual(captured["method"], "POST")
-        self.assertIn("app-manifest/tok123/conversions", captured["url"])
-        self.assertNotIn("Authorization", captured["headers"])
-
-    def test_http_error_becomes_ghError(self):
-        def boom(req, timeout=None):
-            raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, None)
-
-        with mock.patch("urllib.request.urlopen", boom), \
-             self.assertRaises(gh.GhError):
-            gh.convert_manifest("expired")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reverts #71. Reopens #70.

## Why

#71 changed `gh.convert_manifest` from `gh api` to an unauthenticated stdlib
`urllib` request, on the theory that sending `Authorization` was what made
`POST /app-manifest/{code}/conversions` return 404.

That theory was wrong. Follow-up diagnostics on the reporting environment
exchanged a fresh manifest code three ways — `gh api`, `curl`, and `urllib` —
and **all three got an identical genuine 404 from GitHub** (real
`x-github-request-id`, unauthenticated rate-limit headers). Auth was never the
factor. Meanwhile the `urllib` path is strictly worse in a TLS-inspection
environment: `gh` trusts the corporate CA, plain `urllib` does not, so #71
turns GitHub's 404 into an opaque `SSLCertVerificationError`.

So: restore the `gh api` call. The real cause of the manifest-conversion 404
is still open — see #70.

## This change

Straight `git revert` of the #71 merge. `convert_manifest` is back to
`gh api`; the `urllib`-based test in `test_apps.py` is removed with it.

`installer` suite: 25 passing.
