### PR TITLE
fix(install): never resolve the interns ref to the consumer's SHA

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -50,18 +50,27 @@ jobs:
     steps:
       - name: Resolve the interns ref
         id: ref
-        # Precedence: explicit input > the ref the caller pinned this reusable
-        # workflow to (github.job_workflow_ref, ".../install.yml@refs/tags/vX")
-        # > this run's own sha (the workflow_dispatch-on-this-repo case).
+        # Precedence: explicit input (the wrapper defaults this to its own
+        # pinned tag) > the ref the caller pinned this reusable workflow to
+        # (github.job_workflow_ref, ".../install.yml@<ref>") > this run's own
+        # ref (the workflow_dispatch-on-this-repo case). Never github.sha --
+        # in a workflow_call that is the *consumer's* commit, never an interns
+        # ref (#73).
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+          RUN_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          if [[ -n "${{ inputs.ref }}" ]]; then
-            ref="${{ inputs.ref }}"
-          elif [[ -n "${{ github.job_workflow_ref }}" ]]; then
-            ref="${{ github.job_workflow_ref }}"
-            ref="refs/${ref##*@refs/}"
+          if [[ -n "$INPUT_REF" ]]; then
+            ref="$INPUT_REF"
+          elif [[ -n "$JOB_WORKFLOW_REF" ]]; then
+            # "owner/repo/.github/workflows/install.yml@<ref>" -- <ref> is
+            # either a bare tag/branch (wrapper pinned "@v0.1.0") or a fully
+            # qualified "refs/tags/vX" / "refs/heads/x".
+            ref="${JOB_WORKFLOW_REF##*@}"
           else
-            ref="${{ github.sha }}"
+            ref="$RUN_REF"
           fi
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
           echo "Using interns ref: $ref"

--- a/README.md
+++ b/README.md
@@ -239,11 +239,11 @@ which carries the `workflow` scope that `GITHUB_TOKEN` is never granted, so the
 `.github/workflows/*` files can be pushed:
 
 - [`.github/workflows/install.yml`](templates/workflows/install.yml) — a thin
-  `workflow_dispatch` wrapper for the reusable install workflow, pinned to
-  `@v0.1.0`.
+  `workflow_dispatch` wrapper for the reusable install workflow, pinned to the
+  installer version.
 - [`.github/workflows/{issue,code}-pipeline.yml`](templates/workflows) — caller
-  stubs that own the triggers and delegate to the reusable cores, pinned to
-  `@v0.1.0`.
+  stubs that own the triggers and delegate to the reusable cores, pinned to the
+  same version.
 - [`.github/interns.yml`](templates/config/interns.yml) — starter config.
 
 Only missing files are added — a hand-edited one is left untouched. Merge the

--- a/installer/src/interns_install/cli.py
+++ b/installer/src/interns_install/cli.py
@@ -40,6 +40,11 @@ INTERNS_REPO = "abi83/interns"
 # default matches the pin baked into the templates.
 INTERNS_REF = os.environ.get("INTERNS_REF") or "v0.1.0"
 
+# Templates leave the interns ref as this placeholder so the pin always tracks
+# the installer version -- both in the `uses:` line and in each wrapper's
+# `ref:` fallback (never the consumer's commit SHA, see #73).
+REF_PLACEHOLDER = "__INTERNS_REF__"
+
 # Files interns-install stages into the consumer repo, source path in
 # INTERNS_REPO -> destination path in the consumer. GITHUB_TOKEN cannot push
 # .github/workflows/*, so install.yml can't add these itself (see #74) --
@@ -297,7 +302,8 @@ def _collect_missing_files(repo: gh.Repo, base: str, issue_templates: bool) -> d
     wanted: dict[str, str] = {}
     for src, dest in INSTALL_FILES.items():
         if not gh.path_exists(repo.slug, dest, base):
-            wanted[dest] = gh.get_file(INTERNS_REPO, src, INTERNS_REF)
+            content = gh.get_file(INTERNS_REPO, src, INTERNS_REF)
+            wanted[dest] = content.replace(REF_PLACEHOLDER, INTERNS_REF)
 
     if issue_templates and not gh.path_exists(repo.slug, ".github/ISSUE_TEMPLATE", base):
         for name in gh.list_dir(INTERNS_REPO, "templates/issue", INTERNS_REF):

--- a/installer/tests/test_cli.py
+++ b/installer/tests/test_cli.py
@@ -139,6 +139,17 @@ class StageInstallFilesTests(unittest.TestCase):
             ".github/workflows/code-pipeline.yml",
         })
 
+    def test_collect_substitutes_ref_placeholder(self):
+        tmpl = "uses: abi83/interns/.github/workflows/install.yml@__INTERNS_REF__"
+        with mock.patch.object(cli.gh, "path_exists", return_value=False), \
+             mock.patch.object(cli.gh, "get_file", return_value=tmpl), \
+             mock.patch.object(cli, "INTERNS_REF", "v9.9.9"):
+            wanted = _collect_missing_files(self._repo(), "main", issue_templates=False)
+
+        for content in wanted.values():
+            self.assertNotIn("__INTERNS_REF__", content)
+            self.assertIn("@v9.9.9", content)
+
     def test_collect_pulls_issue_templates_when_dir_absent(self):
         with mock.patch.object(cli.gh, "path_exists", return_value=False), \
              mock.patch.object(cli.gh, "list_dir", return_value=["bug.md", "config.yml"]), \

--- a/installer/uv.lock
+++ b/installer/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 2
+requires-python = ">=3.12"
+
+[[package]]
+name = "interns-install"
+version = "0.1.0"
+source = { editable = "." }

--- a/templates/workflows/code-pipeline.yml
+++ b/templates/workflows/code-pipeline.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   pipeline:
-    uses: abi83/interns/.github/workflows/code-pipeline.yml@v0.1.0
+    uses: abi83/interns/.github/workflows/code-pipeline.yml@__INTERNS_REF__
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}

--- a/templates/workflows/install.yml
+++ b/templates/workflows/install.yml
@@ -19,7 +19,9 @@ permissions:
 
 jobs:
   install:
-    uses: abi83/interns/.github/workflows/install.yml@v0.1.0
+    uses: abi83/interns/.github/workflows/install.yml@__INTERNS_REF__
     secrets: inherit
     with:
-      ref: ${{ inputs.ref }}
+      # Fall back to the exact tag this wrapper is pinned to, never to the
+      # consumer's commit SHA.
+      ref: ${{ inputs.ref || '__INTERNS_REF__' }}

--- a/templates/workflows/issue-pipeline.yml
+++ b/templates/workflows/issue-pipeline.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   pipeline:
-    uses: abi83/interns/.github/workflows/issue-pipeline.yml@v0.1.0
+    uses: abi83/interns/.github/workflows/issue-pipeline.yml@__INTERNS_REF__
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}


### PR DESCRIPTION
Closes #73.

## Problem

A consumer wrapper pinned to a tag and dispatched with no `ref` input failed at
"Check out interns": the reusable `install.yml` fell through `inputs.ref` (empty)
and `github.job_workflow_ref` to `github.sha`, which in a `workflow_call` is the
**consumer's** commit — never an interns ref.

## Fix

- **Templates** carry the pin as a `__INTERNS_REF__` placeholder that
  `interns-install` substitutes when it stages the files. The `uses:` pin and the
  new `ref:` fallback both come from one source (the installer version).
- **`install.yml` wrapper** now defaults `ref:` to the pinned tag
  (`${{ inputs.ref || '<tag>' }}`) instead of passing empty.
- **Reusable `install.yml`** precedence: `inputs.ref` > `github.job_workflow_ref`
  (parsed for both `@vX` and `@refs/tags/vX`) > `github.ref` (correct for the
  `workflow_dispatch`-on-this-repo case). The `github.sha` fallback is gone.

## Acceptance criteria

- ✅ Consumer wrapper pinned to a tag, dispatched with no `ref`, checks out
  `abi83/interns` at that tag (via the templated `ref:` default).
- ✅ `workflow_dispatch` on `abi83/interns` resolves to `github.ref`.
- ✅ No path resolves the interns ref to the consumer's commit SHA.

## Tests

Added `test_collect_substitutes_ref_placeholder`; full installer suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)