### PR TITLE
fix(interns-install): preflight the workflow scope before the handoff

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -10,6 +10,10 @@ local caller. If the repo has none, the CLI opens a one-file PR adding
 `.github/workflows/install.yml` (the wrapper from `templates/workflows/`);
 merge it and re-run the CLI, which then dispatches it.
 
+Because that PR writes under `.github/workflows/`, a classic `gh` token needs
+the `workflow` scope; the CLI checks for it up front (unless `--skip-handoff`)
+and stops with a fix hint rather than 404ing at the handoff.
+
 What it does, step by step, and how it fits the rest of setup:
 [the root README](../README.md).
 

--- a/installer/src/interns_install/cli.py
+++ b/installer/src/interns_install/cli.py
@@ -107,6 +107,24 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     return p.parse_args(argv)
 
 
+def _workflow_scope_preflight(con: Console) -> None:
+    """The handoff unconditionally writes `.github/workflows/install.yml`, which
+    GitHub blocks (with an opaque 404) unless a classic token carries the
+    `workflow` scope. `auth_scopes()` is empty for a fine-grained PAT, whose
+    Workflows: write permission we can't see here -- fall through to the
+    existing best-effort behaviour in that case."""
+    scopes = gh.auth_scopes()
+    if not scopes or "workflow" in scopes:
+        return
+    con.error(
+        "your `gh` token is missing the `workflow` scope, required to add "
+        "`.github/workflows/install.yml`. Run "
+        "`gh auth refresh -h github.com -s workflow` (or regenerate the PAT "
+        "with `workflow` checked) and re-run."
+    )
+    sys.exit(1)
+
+
 def _scope_preflight(con: Console, repo: str) -> list[str] | None:
     existing = gh.list_secret_names(repo)
     if existing is None:
@@ -364,6 +382,8 @@ def main(argv: list[str] | None = None) -> int:
 
     con.say(f"target repo: {repo.slug}" + (" (dry run)" if args.dry_run else ""))
 
+    if not args.skip_handoff:
+        _workflow_scope_preflight(con)
     existing_secrets = _scope_preflight(con, repo.slug)
     existing_vars = gh.list_variable_names(repo.slug)
 

--- a/installer/tests/test_cli.py
+++ b/installer/tests/test_cli.py
@@ -50,6 +50,24 @@ class ScopeParseTests(unittest.TestCase):
         self.assertEqual(gh._parse_scopes("Logged in to github.com"), set())
 
 
+class WorkflowScopePreflightTests(unittest.TestCase):
+    def _con(self):
+        return Console(assume_yes=True, dry_run=False)
+
+    def test_classic_token_without_workflow_exits(self):
+        with mock.patch.object(gh, "auth_scopes", return_value={"repo"}):
+            with self.assertRaises(SystemExit):
+                cli._workflow_scope_preflight(self._con())
+
+    def test_classic_token_with_workflow_passes(self):
+        with mock.patch.object(gh, "auth_scopes", return_value={"repo", "workflow"}):
+            cli._workflow_scope_preflight(self._con())
+
+    def test_fine_grained_pat_falls_through(self):
+        with mock.patch.object(gh, "auth_scopes", return_value=set()):
+            cli._workflow_scope_preflight(self._con())
+
+
 CODER = next(s for s in APPS if s.key == "coder")
 
 


### PR DESCRIPTION
Closes #75.

## Problem

`interns-install` runs to the handoff, then dies with an opaque `404` when it
PUTs `.github/workflows/install.yml` — GitHub blocks writes under
`.github/workflows/` for a classic token lacking the `workflow` scope and
returns 404 instead of a useful error. `_scope_preflight` only checked that the
token could list repo secrets.

## Change

- New `_workflow_scope_preflight`: when `gh.auth_scopes()` is non-empty (classic
  PAT) and lacks `workflow`, `con.error(...)` with the fix hint
  (`gh auth refresh -h github.com -s workflow`) and exit before any mutation.
- Empty scopes (fine-grained PAT) fall through to existing best-effort behaviour.
- Gated on `not args.skip_handoff` — that path never stages the workflow file.
- Tests for all three cases; README note.

## Acceptance criteria

- [x] Classic token without `workflow` stops in preflight with the message, before any mutation.
- [x] Token with `workflow` proceeds unchanged.